### PR TITLE
Add full inventory check for crafting hotkey test

### DIFF
--- a/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1,17 +1,17 @@
 /**
  * Jobs Plugin for Bukkit
  * Copyright (C) 2011 Zak Ford <zak.j.ford@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -452,8 +452,12 @@ public class JobsPaymentListener implements Listener {
 	if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getLocation().getWorld().getName()))
 	    return;
 
-	if (!event.isLeftClick() && !event.isRightClick())
+	//Check if inventory is full and player has used the crafting hotkey
+	//Should fix infinite money exploit while still allowing use of the hotkey under most circumstances
+	if (!event.isLeftClick() && !event.isRightClick() && player.getInventory().firstEmpty() == -1) {
+		player.sendMessage(ChatColor.RED + Jobs.getLanguage().getMessage("message.crafting.fullinventory"));
 	    return;
+	}
 
 	// check if in creative
 	if (player.getGameMode().equals(GameMode.CREATIVE) && !Jobs.getGCManager().payInCreative())


### PR DESCRIPTION
Check for a full inventory before returning from the function when the player has pressed their crafting hotkey instead of crafting with their mouse. This should let players continue to craft and be rewarded with the hotkey as long as their inventory is not full.