### PR TITLE
Update pom.xml (remove output configuration)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,9 +129,6 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.3.1</version>
-				<configuration>
-					<outputDirectory>C:\Users\Arte\Desktop\Server\plugins</outputDirectory>
-				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Current output directory for maven-jar-plugin doesn't exist on most computers,(C:\Users\Arte\Desktop\Server\plugins) making the plugin not buildable.