### PR TITLE
Bugfix: Remove duplicate repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,7 @@
 		</dependency>
 	</dependencies>
 	<repositories>
-		<!-- WorldGuard -->
-		<repository>
-			<id>sk89q-repo</id>
-			<url>http://maven.sk89q.com/repo/</url>
-		</repository>
-		<!-- WorldEdit -->
+		<!-- WorldGuard & WorldEdit -->
 		<repository>
 			<id>sk89q-repo</id>
 			<url>http://maven.sk89q.com/repo/</url>


### PR DESCRIPTION
When calling `mvn clean install` it fails due to duplication of repository id:
```
[ERROR] 'repositories.repository.id' must be unique: sk89q-repo -> http://maven.sk89q.com/repo/ vs http://maven.sk89q.com/repo/ @ line 117, column 8

	at org.apache.maven.project.DefaultProjectBuilder.build(DefaultProjectBuilder.java:364)
	at hudson.maven.MavenEmbedder.buildProjects(MavenEmbedder.java:361)
	at hudson.maven.MavenEmbedder.readProjects(MavenEmbedder.java:331)
	at hudson.maven.MavenModuleSetBuild$PomParser.invoke(MavenModuleSetBuild.java:1328)
	at hudson.maven.MavenModuleSetBuild$PomParser.invoke(MavenModuleSetBuild.java:1125)
	at hudson.FilePath.act(FilePath.java:1077)
	at hudson.FilePath.act(FilePath.java:1060)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.parsePoms(MavenModuleSetBuild.java:986)
	at hudson.maven.MavenModuleSetBuild$MavenModuleSetBuildExecution.doRun(MavenModuleSetBuild.java:691)
	at hudson.model.AbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:504)
	at hudson.model.Run.execute(Run.java:1815)
	at hudson.maven.MavenModuleSetBuild.run(MavenModuleSetBuild.java:543)
	at hudson.model.ResourceController.execute(ResourceController.java:97)
	at hudson.model.Executor.run(Executor.java:429)
```