### PR TITLE
Fixed IndexOutOfBoundsException on signs update

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Signs/SignUtil.java
+++ b/src/main/java/com/gamingmesh/jobs/Signs/SignUtil.java
@@ -175,6 +175,8 @@ public class SignUtil {
 		if (!UpdateHead(sign, PlayerList.get(0).getPlayerName(), timelapse))
 		    timelapse--;
 	    } else {
+	    	if (one.GetNumber() > PlayerList.size())
+	    		continue;
 		TopList pl = PlayerList.get(one.GetNumber() - 1);
 		String PlayerName = pl.getPlayerName();
 		if (PlayerName.length() > 8) {


### PR DESCRIPTION
As described in #394 an IndexOutOfBoundsException is fired on sign update if the PlayersList is smaller than the requested rank number on the sign.
This fix cancels the sign update for these signs so that no IndexOutOfBoundsException is fired.

After merge the pull request, you can close #394 