### PR TITLE
Add JobsPrePaymentEvent

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
 
+import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
@@ -997,6 +998,17 @@ public class Jobs extends JavaPlugin {
 
 	    Boost boost = getPlayerManager().getFinalBonus(jPlayer, noneJob);
 
+        JobsPrePaymentEvent JobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), noneJob, income, pointAmount);
+        Bukkit.getServer().getPluginManager().callEvent(JobsPrePaymentEvent);
+        // If event is canceled, don't do anything
+        if (JobsPrePaymentEvent.isCancelled()) {
+            income = 0D;
+            pointAmount = 0D;
+        } else {
+            income = JobsPrePaymentEvent.getAmount();
+            pointAmount = JobsPrePaymentEvent.getPoints();
+        }
+
 	    // Calculate income
 
 	    if (income != 0D) {
@@ -1097,7 +1109,19 @@ public class Jobs extends JavaPlugin {
 			    player.giveExp(expInt);
 		    }
 		}
+
 		Boost boost = getPlayerManager().getFinalBonus(jPlayer, prog.getJob(), ent, victim);
+
+		JobsPrePaymentEvent JobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), prog.getJob(), income, pointAmount);
+		Bukkit.getServer().getPluginManager().callEvent(JobsPrePaymentEvent);
+		// If event is canceled, don't do anything
+		if (JobsPrePaymentEvent.isCancelled()) {
+            income = 0D;
+            pointAmount = 0D;
+        } else {
+		    income = JobsPrePaymentEvent.getAmount();
+		    pointAmount = JobsPrePaymentEvent.getPoints();
+        }
 
 		// Calculate income
 		if (income != 0D) {

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -30,7 +30,6 @@ import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
 
-import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
@@ -56,6 +55,7 @@ import com.gamingmesh.jobs.Placeholders.PlaceholderAPIHook;
 import com.gamingmesh.jobs.Signs.SignUtil;
 import com.gamingmesh.jobs.WorldGuard.WorldGuardManager;
 import com.gamingmesh.jobs.api.JobsExpGainEvent;
+import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
 import com.gamingmesh.jobs.commands.JobsCommands;
 import com.gamingmesh.jobs.config.BlockProtectionManager;
 import com.gamingmesh.jobs.config.BossBarManager;

--- a/src/main/java/com/gamingmesh/jobs/api/JobsPrePaymentEvent.java
+++ b/src/main/java/com/gamingmesh/jobs/api/JobsPrePaymentEvent.java
@@ -1,0 +1,55 @@
+package com.gamingmesh.jobs.api;
+
+import com.gamingmesh.jobs.container.Job;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public final class JobsPrePaymentEvent extends BaseEvent implements Cancellable {
+    private OfflinePlayer offlinePlayer;
+    private double money;
+    private double points;
+    private Job job;
+    private boolean cancelled = false;
+
+    public JobsPrePaymentEvent(OfflinePlayer offlinePlayer, Job job, double money, double points) {
+        this.offlinePlayer = offlinePlayer;
+        this.money = money;
+        this.points = points;
+    }
+
+    public OfflinePlayer getPlayer() {
+        return offlinePlayer;
+    }
+
+    public double getAmount() {
+        return money;
+    }
+
+    public double getPoints() {
+        return points;
+    }
+
+    public Job getJob() {
+        return job;
+    }
+
+    public void setAmount(double money) {
+        this.money = money;
+    }
+
+    public void setPoints(double points) {
+        this.points = points;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    @Override
+    public void setCancelled(boolean cancelled) {
+        this.cancelled = cancelled;
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/api/JobsPrePaymentEvent.java
+++ b/src/main/java/com/gamingmesh/jobs/api/JobsPrePaymentEvent.java
@@ -14,6 +14,7 @@ public final class JobsPrePaymentEvent extends BaseEvent implements Cancellable 
     private boolean cancelled = false;
 
     public JobsPrePaymentEvent(OfflinePlayer offlinePlayer, Job job, double money, double points) {
+        this.job = job;
         this.offlinePlayer = offlinePlayer;
         this.money = money;
         this.points = points;


### PR DESCRIPTION
Add event to allow plugins to modify payments per player and per job before they're added to the delayed payment batch.

Implements #450 