### PR TITLE
One more fix for showing messages without payment.

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/economy/BufferedEconomy.java
+++ b/src/main/java/com/gamingmesh/jobs/economy/BufferedEconomy.java
@@ -1,17 +1,17 @@
 /**
  * Jobs Plugin for Bukkit
  * Copyright (C) 2011 Zak Ford <zak.j.ford@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -218,6 +218,9 @@ public class BufferedEconomy {
 	    ToggleBarHandling.getActionBarToggle().put(playername, true);
 
 	if (!ToggleBarHandling.getActionBarToggle().containsKey(playername))
+	    return;
+
+	if (payment.getAmount() == 0.0D && payment.getPoints() == 0.0D && payment.getExp() == 0.0D)
 	    return;
 
 	Boolean show = ToggleBarHandling.getActionBarToggle().get(playername);


### PR DESCRIPTION
If money, xp and point payment set to 0 with external API's it still shows action bar even without payment.

It was fixed with #513 but for some reason removed with https://github.com/Zrips/Jobs/commit/a07cbb246d3ebc69b69f140723b5535b2df84383