### PR TITLE
Update jobConfig.yml

### DIFF
--- a/src/main/resources/jobConfig.yml
+++ b/src/main/resources/jobConfig.yml
@@ -1916,7 +1916,7 @@ Jobs:
         income: 1.5
         points: 1.5
         experience: 3.0
-      beetroots-7:
+      beetroots-3:
         income: 1.5
         points: 1.5
         experience: 3.0


### PR DESCRIPTION
Bug fix: harvesting beetroot not rewarding money for farmer job.
Beetroot harvesting reward for the Farmer job was set to give reward at stage 7 of beetroot plant. This was preventing money from being rewarding for beetroot harvest as beetroots only have growth stages 0, 1, 2, and 3. Changing 7 to 3 fixed this in our server.