### PR TITLE
Fix: Quests beeing reset by making an action not on the quest.

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
@@ -1019,7 +1019,8 @@ public class JobsPlayer {
 	    int i = 0;
 	    while (i <= job.getQuests().size()) {
 		++i;
-		Quest q = job.getNextQuest(getQuestNameList(job, type), getJobProgression(job).getLevel());
+		List<String> currentQuests = new ArrayList<>(g.keySet());
+		Quest q = job.getNextQuest(currentQuests, getJobProgression(job).getLevel());
 		if (q == null)
 		    continue;
 		QuestProgression qp = new QuestProgression(q);


### PR DESCRIPTION
Problem described here https://github.com/Zrips/Jobs/issues/698

I've been debugging and I've found the problem was on a method that handles the assign of new quests. It did overwrite the quests that the player already had, therefore reseting its progress to zero.

I've fixed that by passing the currentQuests on the exclude parameter of that method, instead of the former list of quests from the job and action type.

