### PR TITLE
Milk Quests, Fix Dye action, added leather_horse_armor

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -229,20 +229,6 @@ public class JobsPaymentListener implements Listener {
 	if (jPlayer == null)
 	    return;
 
-	boolean found = false;
-	t: for (JobProgression prog : jPlayer.getJobProgression()) {
-	    for (JobInfo info : jPlayer.getJobProgression(prog.getJob()).getJob().getJobInfo(ActionType.MILK)) {
-		if (info.getActionType() == ActionType.MILK) {
-		    found = true;
-		    break t;
-		}
-	    }
-	}
-
-	if (!found) {
-	    return;
-	}
-
 	if (Jobs.getGCManager().CowMilkingTimer > 0) {
 	    if (cow.hasMetadata(CowMetadata)) {
 		long time = cow.getMetadata(CowMetadata).get(0).asLong();
@@ -634,6 +620,7 @@ public class JobsPaymentListener implements Listener {
 	    case LEATHER_CHESTPLATE:
 	    case LEATHER_HELMET:
 	    case LEATHER_LEGGINGS:
+	    case LEATHER_HORSE_ARMOR:
 		leather = true;
 		break;
 	    default:
@@ -654,7 +641,7 @@ public class JobsPaymentListener implements Listener {
 
 	// Check Dyes
 	if (y >= 2) {
-	    if ((third != null && third.isDye() || second != null && second.isDye()) && leather) {
+	    if ((third != null && third.isDye() || second != null && second.isDye() || first != null && first.isDye()) && leather) {
 		Jobs.action(jPlayer, new ItemActionInfo(sourceItems[0], ActionType.DYE));
 		for (ItemStack OneDye : DyeStack) {
 		    Jobs.action(jPlayer, new ItemActionInfo(OneDye, ActionType.DYE));

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -228,6 +228,27 @@ public class JobsPaymentListener implements Listener {
 	JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(player);
 	if (jPlayer == null)
 	    return;
+	
+    boolean found = false;
+    t: for (JobProgression prog : jPlayer.getJobProgression()) {
+        for (JobInfo info : jPlayer.getJobProgression(prog.getJob()).getJob().getJobInfo(ActionType.MILK)) {
+        if (info.getActionType() == ActionType.MILK) {
+            found = true;
+            break t;
+        }
+        }
+	    for (Quest q : prog.getJob().getQuests()) {
+			if (q != null && q.hasAction(ActionType.MILK)) {
+	            found = true;
+	            break t;
+			}
+	    }
+    }
+
+    if (!found) {
+        return;
+    }
+
 
 	if (Jobs.getGCManager().CowMilkingTimer > 0) {
 	    if (cow.hasMetadata(CowMetadata)) {

--- a/src/main/resources/jobConfig.yml
+++ b/src/main/resources/jobConfig.yml
@@ -1742,7 +1742,7 @@ Jobs:
         Name: "Regular Joe"
         Objectives:
         - Breed;Sheep;10
-        - Shear;White;10
+        - Shear;WHITE;10
         - Milk;Cow;3
         RewardCommands:
         - "money give [playerName] 100"

--- a/src/main/resources/jobConfig.yml
+++ b/src/main/resources/jobConfig.yml
@@ -1742,7 +1742,7 @@ Jobs:
         Name: "Regular Joe"
         Objectives:
         - Breed;Sheep;10
-        - Shear;WHITE;10
+        - Shear;White;10
         - Milk;Cow;3
         RewardCommands:
         - "money give [playerName] 100"


### PR DESCRIPTION
Hey there

I was setting a few common quests for jobs and found that Milk actions didn't work except on the Jobs that pays for milking(Farmer). Debugging I found this piece of code is the answer.

I'm not sure why is it there, because when checking quests or paying it already checks that out. So check if there's something I missed. As far as I tested, it now works, and doesn't pay nor anything if user hasn't got that action on its jobs.
```java


	boolean found = false;
	t: for (JobProgression prog : jPlayer.getJobProgression()) {
	    for (JobInfo info : jPlayer.getJobProgression(prog.getJob()).getJob().getJobInfo(ActionType.MILK)) {
		if (info.getActionType() == ActionType.MILK) {
		    found = true;
		    break t;
		}
	    }
	}

	if (!found) {
	    return;
	}
```
Later, when I was testing dye quests, I found that the order in which you put the dye and the leather item caused the action to get done or not. Therefore if you set the dye as the first item, it didn't work.  I also took the opportunity to add the LEATHER_HORSE_ARMOR as an item that can be dyed.

I Also found that while shear action was getting paid, shear quests didn't work. On the process quest, when it checks if the COLOR of the sheep is on the objectives, it's case-sensitive, so I modified the jobConfig docs to change that to uppercase. (I wasn't sure how to make that ignoring uppercase, would like to if it's possible, to avoid any future headache).


Commit:
```
- Fix: Milk quests not working if palyer doesn't have a job which pays for milking.
- Fix: Dye action not working if dye is the first item on crafting
- Feature: Added LEATHER_HORSE_ARMOR as item which can be dyed.
- Docs: Specified caps on Shear quest. Otherwise it doesn't work.
```