### PR TITLE
:ALL Meta for all colors of a material

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
+++ b/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
@@ -2510,11 +2510,18 @@ public enum CMIMaterial {
     }
 
     public static String getGeneralMaterialName(String fullName) {
-        fullName = fullName.toUpperCase();
-        if (fullName.startsWith("STRIPPED")) {
-            return fullName.replaceFirst("_[^_]+", "");
-        } else {
-            return fullName.replaceFirst(".+?_", "");
+        String newName = fullName.toUpperCase();
+        if (newName.startsWith("STRIPPED")) {
+            return newName.replaceFirst("_[^_]+", "");
         }
+        else if (newName.matches("^(DARK|LIGHT).+")) {
+            return newName.replaceFirst(".+?_.+?_", "");
+        }
+        else if (newName.matches(
+                "^(WHITE|ORANGE|MAGENTA|YELLOW|LIME|PINK|GRAY|CYAN|PURPLE|BLUE|BROWN|GREEN|RED|BLACK|" +
+                "OAK|SPRUCE|BIRCH|JUNGLE|ACACIA).+")) {
+            return newName.replaceFirst(".+?_", "");
+        }
+        return fullName;
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
+++ b/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
@@ -775,7 +775,6 @@ public enum CMIMaterial {
     SPRUCE_TRAPDOOR(10289, "Spruce Trapdoor"),
     SPRUCE_WOOD(32328, "Spruce Wood"),
     SQUID_SPAWN_EGG(383, 94, 10682, "Squid Spawn Egg", "Spawn Squid"),
-    STAINED_GLASS(10095, "Stained Glass"),
     STICK(280, 0, 9773, "Stick"),
     STICKY_PISTON(29, 0, 18127, "Sticky Piston", "PISTON_STICKY_BASE"),
     STONE(1, 0, 22948, "Stone"),
@@ -1198,7 +1197,7 @@ public enum CMIMaterial {
 	for (CMIMaterial one : CMIMaterial.values()) {
 	    if (one.getLegacyId() == null)
 		continue;
-	    if (one.getLegacyId() != mat.getLegacyId())
+	    if (!one.getLegacyId().equals(mat.getLegacyId()))
 		continue;
 	    ls.add(one);
 	}
@@ -1229,7 +1228,7 @@ public enum CMIMaterial {
 	for (CMIMaterial one : CMIMaterial.values()) {
 	    if (one.getLegacyId() == null)
 		continue;
-	    if (one.getLegacyId() != mat.getLegacyId())
+	    if (!one.getLegacyId().equals(mat.getLegacyId()))
 		continue;
 	    if (one.getLegacyData() == id)
 		return one;
@@ -1241,9 +1240,9 @@ public enum CMIMaterial {
     public static CMIMaterial get(String id) {
 	if (id == null)
 	    return CMIMaterial.NONE;
-	Integer ids = null;
-	Integer data = null;
-	id = id.replace("_", "").replace(" ", "").replace("minecraft:", "").toLowerCase();
+	Integer ids;
+	Integer data;
+	id = id.replaceAll("_| |minecraft:", "").toLowerCase();
 
 	if (id.contains(":")) {
 	    try {
@@ -1252,7 +1251,7 @@ public enum CMIMaterial {
 		if (ids <= 0)
 		    return CMIMaterial.NONE;
 		return get(ids, data);
-	    } catch (Exception ex) {
+	    } catch (Exception ignored) {
 	    }
 
 	    try {
@@ -1269,7 +1268,7 @@ public enum CMIMaterial {
 			return mat;
 		    }
 		}
-	    } catch (Exception ex) {
+	    } catch (Exception ignored) {
 	    }
 	}
 
@@ -1291,7 +1290,7 @@ public enum CMIMaterial {
 	    if (mat != null) {
 		return mat;
 	    }
-	} catch (Exception ex) {
+	} catch (Exception ignored) {
 	}
 
 	return CMIMaterial.NONE;
@@ -2508,5 +2507,14 @@ public enum CMIMaterial {
 
     public void setBukkitName(String bukkitName) {
 	this.bukkitName = bukkitName;
+    }
+
+    public static String getGeneralMaterialName(String fullName) {
+        fullName = fullName.toUpperCase();
+        if (fullName.startsWith("STRIPPED")) {
+            return fullName.replaceFirst("_[^_]+", "");
+        } else {
+            return fullName.replaceFirst(".+?_", "");
+        }
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
+++ b/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
@@ -775,6 +775,7 @@ public enum CMIMaterial {
     SPRUCE_TRAPDOOR(10289, "Spruce Trapdoor"),
     SPRUCE_WOOD(32328, "Spruce Wood"),
     SQUID_SPAWN_EGG(383, 94, 10682, "Squid Spawn Egg", "Spawn Squid"),
+    STAINED_GLASS(10095, "Stained Glass"),
     STICK(280, 0, 9773, "Stick"),
     STICKY_PISTON(29, 0, 18127, "Sticky Piston", "PISTON_STICKY_BASE"),
     STONE(1, 0, 22948, "Stone"),

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1229,7 +1229,7 @@ public class ConfigManager {
 				Integer matId = null;
 				try {
 				    matId = Integer.valueOf(myKey);
-				} catch (NumberFormatException e) {
+				} catch (NumberFormatException ignored) {
 				}
 				if (matId != null) {
 				    material = CMIMaterial.get(matId);
@@ -1402,7 +1402,10 @@ public class ConfigManager {
 				subType = myKey.split(":")[1];
 			    }
 			}
-
+			if (subType.equalsIgnoreCase(":ALL")) {
+				meta = "ALL";
+				type = CMIMaterial.getGeneralMaterialName(type);
+			}
 			if (type == null) {
 			    log.warning("Job " + jobKey + " has an invalid " + actionType.getName() + " type property: " + key + "!");
 			    continue;

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1402,13 +1402,13 @@ public class ConfigManager {
 				subType = myKey.split(":")[1];
 			    }
 			}
-			if (subType.equalsIgnoreCase(":ALL")) {
-				meta = "ALL";
-				type = CMIMaterial.getGeneralMaterialName(type);
-			}
 			if (type == null) {
 			    log.warning("Job " + jobKey + " has an invalid " + actionType.getName() + " type property: " + key + "!");
 			    continue;
+			}
+			if (":ALL".equalsIgnoreCase(subType)) {
+				meta = "ALL";
+				type = CMIMaterial.getGeneralMaterialName(type);
 			}
 
 			if (actionType == ActionType.TNTBREAK)

--- a/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
@@ -1,11 +1,8 @@
 package com.gamingmesh.jobs.config;
 
 import java.io.File;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.enchantments.Enchantment;
@@ -51,6 +48,9 @@ public class NameTranslatorManager {
 	    case BREW:
 	    case FISH:
 	    case STRIPLOGS:
+		String fallbackMaterialName = Arrays.stream(materialName.split("\\s|:"))
+				.map(word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase())
+				.collect(Collectors.joining(" ")); // returns capitalized word (from this -> To This)
 		materialName = materialName.replace(" ", "");
 
 		CMIMaterial mat = CMIMaterial.get(materialName.replace(" ", ""));
@@ -82,6 +82,9 @@ public class NameTranslatorManager {
 			NameList nameMeta = ListOfNames.get(CMIMaterial.get(meta.replace(" ", "")));
 			if (nameLs != null && nameMeta != null) {
 			    return nameLs + ":" + nameMeta;
+			}
+			if (mat.equals(CMIMaterial.NONE)) {
+				return fallbackMaterialName;
 			}
 
 			return mat.getName();

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -225,28 +225,31 @@ public class Job {
     }
 
     public JobInfo getJobInfo(ActionInfo action, int level) {
-	BiPredicate<JobInfo, ActionInfo> condition = (jobInfo, actionInfo) -> {
-	if (actionInfo instanceof PotionItemActionInfo) {
-	    return jobInfo.getName().equalsIgnoreCase(((PotionItemActionInfo) action).getNameWithPotion()) ||
-	    (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(((PotionItemActionInfo) action).getNameWithPotion());
-	}
+        BiPredicate<JobInfo, ActionInfo> condition = (jobInfo, actionInfo) -> {
+            if (actionInfo instanceof PotionItemActionInfo) {
+                return jobInfo.getName().equalsIgnoreCase(((PotionItemActionInfo) action).getNameWithPotion()) ||
+                        (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(((PotionItemActionInfo) action).getNameWithPotion());
+            }
+            return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||
+                    (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
+                    jobInfo.getName().equalsIgnoreCase(action.getName());
+        };
 
-	return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||
-		(jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
-		jobInfo.getName().equalsIgnoreCase(action.getName());
-	};
-
-	for (JobInfo info : getJobInfo(action.getType())) {
-	    if (condition.test(info, action)) {
-		if (!info.isInLevelRange(level)) {
-		    break;
-		}
-
-		return info;
-	    }
-	}
-
-	return null;
+        String shortActionName = action.getName().replaceFirst(".+?_", "");
+        for (JobInfo info : getJobInfo(action.getType())) {
+            if (condition.test(info, action)) {
+                if (!info.isInLevelRange(level)) {
+                    break;
+                }
+                return info;
+            }
+            Jobs.consoleMsg("ActionName: " + action.getName() + " | Shortname:" + shortActionName + " | JobInfoName: " + info.getName());
+            if ((shortActionName + ":ALL").equalsIgnoreCase(info.getName())) {
+                Jobs.consoleMsg("&eALL Block reached!");
+                return info;
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -226,11 +226,10 @@ public class Job {
     }
 
     public JobInfo getJobInfo(ActionInfo action, int level) {
-	BiPredicate<JobInfo, ActionInfo> condition = (jobInfo, actionInfo) -> {
-	return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||
-	    (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
-	    jobInfo.getName().equalsIgnoreCase(action.getName());
-	};
+	BiPredicate<JobInfo, ActionInfo> condition = (jobInfo, actionInfo) ->
+            jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||
+	        (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
+	        jobInfo.getName().equalsIgnoreCase(action.getName());
 
         String shortActionName = CMIMaterial.getGeneralMaterialName(action.getName());
         for (JobInfo info : getJobInfo(action.getType())) {

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -18,6 +18,7 @@
 
 package com.gamingmesh.jobs.container;
 
+import com.gamingmesh.jobs.CMILib.CMIMaterial;
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.actions.PotionItemActionInfo;
 import com.gamingmesh.jobs.resources.jfep.Parser;
@@ -235,7 +236,7 @@ public class Job {
                     jobInfo.getName().equalsIgnoreCase(action.getName());
         };
 
-        String shortActionName = action.getName().replaceFirst(".+?_", "");
+        String shortActionName = CMIMaterial.getGeneralMaterialName(action.getName());
         for (JobInfo info : getJobInfo(action.getType())) {
             if (condition.test(info, action)) {
                 if (!info.isInLevelRange(level)) {

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -244,9 +244,7 @@ public class Job {
                 }
                 return info;
             }
-            Jobs.consoleMsg("ActionName: " + action.getName() + " | Shortname:" + shortActionName + " | JobInfoName: " + info.getName());
             if ((shortActionName + ":ALL").equalsIgnoreCase(info.getName())) {
-                Jobs.consoleMsg("&eALL Block reached!");
                 return info;
             }
         }


### PR DESCRIPTION
I saw that you looked for help in [this issue](https://github.com/Zrips/Jobs/issues/271) and I tried something..
Main idea: Add a "-all" and remove the color e.g. for stained glass colors it's `stained_glass-all`. 
This makes every material with colors flexible configurable to match all colors without listing each of them which leads to an exploding /jobs info view.

But, this PR is still not ready to pull as I ask you to help me out with that material naming. If I write stained_glass-ALL into the config, it's name will be LEGACY_STAINED_GLASS but it should be STAINED_GLASS. Don't know where that legacy prefix comes from.

For now I left that one console debugging line to make clear what I mean. 
I think thats the only barrier to get this work.