### PR TITLE
Change PIG_ZOMBIE to Zombified_Piglin

### DIFF
--- a/src/main/resources/jobConfig.yml
+++ b/src/main/resources/jobConfig.yml
@@ -2242,7 +2242,7 @@ Jobs:
         income: 5.0
         points: 5
         experience: 5.0
-      PIG_ZOMBIE:
+      Zombified_Piglin:
         income: 5.0
         points: 5
         experience: 5.0


### PR DESCRIPTION
This solves the `[Server thread/WARN]: [Jobs] Job Hunter has an invalid Kill type property: PIG_ZOMBIE!` when generating the default `jobConfig.yml`.

In MC 1.11 (16w32a), Mojang changed the entity ID: `PigZombie` to `zombie_pigman`. Then renamed it again in MC 1.16 (20w09a) from `zombie_pigman` to `zombified_piglin`.