### PR TITLE
Fix max jobs, respect negated permissions, add cumulative option

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PermissionManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PermissionManager.java
@@ -20,6 +20,7 @@ package com.gamingmesh.jobs;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.Bukkit;
 import org.bukkit.World;
@@ -119,7 +120,11 @@ public class PermissionManager {
 	return getMaxPermission(jPlayer, perm, false);
     }
 
-    public Double getMaxPermission(JobsPlayer jPlayer, String perm, boolean force) {
+	public Double getMaxPermission(JobsPlayer jPlayer, String perm, boolean force) {
+		return getMaxPermission(jPlayer, perm, force, true);
+	}
+
+    public Double getMaxPermission(JobsPlayer jPlayer, String perm, boolean force, boolean cumulative) {
 	if (jPlayer == null || jPlayer.getPlayer() == null)
 	    return 0D;
 
@@ -138,23 +143,22 @@ public class PermissionManager {
 	    return 0D;
 	}
 
-	Double amount = 0D;
-	for (String uno : permissions.keySet()) {
-	    if (uno.startsWith(perm)) {
-		double t = 0d;
-		try {
-		    t = Double.parseDouble(uno.replace(perm, ""));
-		} catch (NumberFormatException e) {
-		}
+	double amount = 0D;
 
-		if (uno.startsWith("jobs.max")) {
-		    if (amount == 0D || t > amount) {
-			amount = t;
-		    }
-		} else {
-		    amount += t;
+	for (Map.Entry<String, Boolean> permission : permissions.entrySet()) {
+		if (!permission.getKey().startsWith(perm) || !permission.getValue())
+			continue;
+
+		try {
+			double temp = Double.parseDouble(permission.getKey().replace(perm, ""));
+
+			if (cumulative)
+				amount += temp;
+			else if (temp > amount)
+				amount = temp;
+
+		} catch (NumberFormatException ignored) {
 		}
-	    }
 	}
 
 	return amount;

--- a/src/main/java/com/gamingmesh/jobs/Placeholders/Placeholder.java
+++ b/src/main/java/com/gamingmesh/jobs/Placeholders/Placeholder.java
@@ -554,7 +554,7 @@ public class Placeholder {
 			return convert(true);
 
 			case maxjobs:
-			    int max = Jobs.getPermissionManager().getMaxPermission(user, "jobs.max").intValue();
+			    int max = Jobs.getPermissionManager().getMaxPermission(user, "jobs.max", false, false).intValue();
 			    max = max == 0 ? Jobs.getGCManager().getMaxJobs() : max;
 			    return Integer.toString(max);
 

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -783,7 +783,7 @@ public class PlayerManager {
      * @return True if he have permission
      */
     public boolean getJobsLimit(JobsPlayer jPlayer, short currentCount) {
-	int max = Jobs.getPermissionManager().getMaxPermission(jPlayer, "jobs.max").intValue();
+	int max = Jobs.getPermissionManager().getMaxPermission(jPlayer, "jobs.max", false, false).intValue();
 	max = max == 0 ? Jobs.getGCManager().getMaxJobs() : max;
 	return max > currentCount;
     }


### PR DESCRIPTION
There were a few changes to how numbered permissions were calculated. This fixes the following issues with those changes:

1. Max jobs now properly take the highest value instead of cumulating their value.
2. Negated permissions are now ignored instead of also counting towards the total value.
3. A cumulative boolean option has now been added. To preserve previous functionality, I set the default to true.
You may want to consider changing the default to false and adjusting the methods where it actually should be cumulative.