### PR TITLE
fix for #940 (stripping logs are respected as block place actions)

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -423,6 +423,10 @@ public class JobsPaymentListener implements Listener {
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onBlockPlace(BlockPlaceEvent event) {
+	// A tool should not trigger a BlockPlaceEvent (fixes stripping logs bug #940)
+	if (CMIMaterial.get(event.getItemInHand().getType()).isTool())
+		return;
+
 	Block block = event.getBlock();
 
 	//disabling plugin in world


### PR DESCRIPTION
This fixes #940 

Please test if it works with the latest version, because I could only test it with a much older version before you changed some dependencies.

Btw:
Maven reimport fails because of the following dependencies aren't found:
io.lumine.xikage.MythicMobs:4.9.1
com.github.OmerBenGera.WildStackerAPI:master-SNAPSHOT
com.github.Nathat23.StackMob-5:master-SNAPSHOT