### PR TITLE
Fix StoneCutter exploit (unlimited craft action)

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -878,7 +878,7 @@ public class JobsPaymentListener implements Listener {
 	    return;
 
 	if (Version.isCurrentEqualOrHigher(Version.v1_14_R1) && inv instanceof StonecutterInventory) {
-		if(event.getAction() != InventoryAction.DROP_ONE_SLOT) {
+		if (event.getAction() != InventoryAction.DROP_ONE_SLOT) {
 			Jobs.action(jPlayer, new ItemActionInfo(resultStack, ActionType.CRAFT));
 		}
 	    return;

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -67,6 +67,7 @@ import org.bukkit.event.entity.SlimeSplitEvent;
 import org.bukkit.event.hanging.HangingBreakByEntityEvent;
 import org.bukkit.event.hanging.HangingPlaceEvent;
 import org.bukkit.event.inventory.BrewEvent;
+import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.CraftItemEvent;
 import org.bukkit.event.inventory.FurnaceSmeltEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
@@ -877,7 +878,9 @@ public class JobsPaymentListener implements Listener {
 	    return;
 
 	if (Version.isCurrentEqualOrHigher(Version.v1_14_R1) && inv instanceof StonecutterInventory) {
-	    Jobs.action(jPlayer, new ItemActionInfo(resultStack, ActionType.CRAFT));
+		if(event.getAction() != InventoryAction.DROP_ONE_SLOT) {
+			Jobs.action(jPlayer, new ItemActionInfo(resultStack, ActionType.CRAFT));
+		}
 	    return;
 	}
 


### PR DESCRIPTION
To reproduce:

1) Add this to a job config:
      quartz_pillar:
        income: 1
        point: 1
        experience: 1

2) Join the job.

3) Take Quartz Block and open a StoneCutter

4) Craft one quartz pillar and keep it on your mouse. Keep your mouse on the craft and spam your drop key.

Video from a player: https://www.youtube.com/watch?v=EJv6rqBk0Is