### PR TITLE
added "color-all" for shear action (#966)

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
+++ b/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
@@ -2624,6 +2624,10 @@ public enum CMIMaterial {
 	    return newName.replaceFirst(".+?_", "");
 	}
 
+	if (newName.matches("(?i)^(WHITE|ORANGE|MAGENTA|YELLOW|LIME|PINK|GRAY|CYAN|PURPLE|BLUE|BROWN|GREEN|RED|BLACK)$")) {
+	    return "color";
+    }
+
 	return fullName;
     }
 

--- a/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
+++ b/src/main/java/com/gamingmesh/jobs/CMILib/CMIMaterial.java
@@ -2624,9 +2624,10 @@ public enum CMIMaterial {
 	    return newName.replaceFirst(".+?_", "");
 	}
 
-	if (newName.matches("(?i)^(WHITE|ORANGE|MAGENTA|YELLOW|LIME|PINK|GRAY|CYAN|PURPLE|BLUE|BROWN|GREEN|RED|BLACK)$")) {
+	if (newName.matches("(?i)^(WHITE|ORANGE|MAGENTA|YELLOW|LIME|PINK|GRAY|CYAN|PURPLE|BLUE|BROWN|GREEN|RED|BLACK|" +
+	    "LIGHT_GRAY|LIGHT_BLUE|)$")) {
 	    return "color";
-    }
+	}
 
 	return fullName;
     }

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -389,12 +389,12 @@ public class ConfigManager {
 	    meta = "";
 	int id = 0;
 
-	if (myKey.contains("-")) {
+	if (myKey.contains("-") && !myKey.endsWith("-all")) {
 	    // uses subType
 	    subType = ":" + myKey.split("-")[1];
 	    meta = myKey.split("-")[1];
 	    myKey = myKey.split("-")[0];
-	} else if (myKey.contains(":")) { // when we uses tipped arrow effect types
+	} else if (myKey.contains(":") && !myKey.endsWith(":all")) { // when we uses tipped arrow effect types
 	    String[] split = myKey.split(":");
 	    meta = split.length > 1 ? split[1] : myKey;
 	    myKey = split[0];
@@ -592,7 +592,7 @@ public class ConfigManager {
 
 	    type = enchant == null ? myKey : enchant.toString();
 	} else if (actionType == ActionType.CUSTOMKILL || actionType == ActionType.COLLECT || actionType == ActionType.MMKILL
-	    || actionType == ActionType.SHEAR || actionType == ActionType.BAKE || actionType == ActionType.BOSS) {
+	    || actionType == ActionType.BAKE || actionType == ActionType.BOSS) {
 	    type = myKey;
 	} else if (actionType == ActionType.EXPLORE) {
 	    type = myKey;
@@ -615,6 +615,13 @@ public class ConfigManager {
 	    if (myKey.contains(":")) {
 		subType = myKey.split(":")[1];
 	    }
+	} else if (actionType == ActionType.SHEAR) {
+		if (myKey.startsWith("color") && (myKey.endsWith("-all") || myKey.endsWith(":all"))) {
+		    subType = ":all";
+		    type = myKey.split(":|-")[0];
+		} else {
+		    type = myKey;
+		}
 	}
 
 	if (type == null) {
@@ -624,13 +631,8 @@ public class ConfigManager {
 
 	if (":ALL".equalsIgnoreCase(subType)) {
 	    meta = "ALL";
-	    type = CMIMaterial.getGeneralMaterialName(type);
-	}
-
-	// case for color-all
-	if (actionType == ActionType.SHEAR && myKey.startsWith("color") && ":ALL".equalsIgnoreCase(subType)) {
-		meta = "ALL";
-		type = "color";
+	    // case for ":all" identifier
+	    type = (actionType == ActionType.SHEAR && myKey.startsWith("color")) ? "color" : CMIMaterial.getGeneralMaterialName(type);
 	}
 
 	if (actionType == ActionType.TNTBREAK)

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -627,6 +627,12 @@ public class ConfigManager {
 	    type = CMIMaterial.getGeneralMaterialName(type);
 	}
 
+	// case for color-all
+	if (actionType == ActionType.SHEAR && myKey.startsWith("color") && ":ALL".equalsIgnoreCase(subType)) {
+		meta = "ALL";
+		type = "color";
+	}
+
 	if (actionType == ActionType.TNTBREAK)
 	    Jobs.getGCManager().setTntFinder(true);
 

--- a/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
@@ -29,7 +29,7 @@ public class NameTranslatorManager {
 	return Translate(materialName, info.getActionType(), info.getId(), info.getMeta(), info.getName());
     }
 
-    public String Translate(String materialName, ActionType action, Integer id, String meta, String mame) {
+    public String Translate(String materialName, ActionType action, Integer id, String meta, String name) {
 	// Translating name to user friendly
 	if (Jobs.getGCManager().UseCustomNames)
 	    switch (action) {
@@ -63,7 +63,7 @@ public class NameTranslatorManager {
 		return nameLs.getName();
 	    }
 
-		if (mame != null && !mame.isEmpty()) {
+		if (name != null && !name.isEmpty()) {
 		    mat = CMIMaterial.get(materialName.replace(" ", ""));
 		    nameLs = ListOfNames.get(mat);
 
@@ -114,41 +114,40 @@ public class NameTranslatorManager {
 			return one.getName();
 		    }
 		    ids = one.getMinecraftName();
-		    if (ids.equalsIgnoreCase(mame)) {
+		    if (ids.equalsIgnoreCase(name)) {
 			return one.getName();
 		    }
 		}
 		break;
 	    case ENCHANT:
-		String name = materialName;
+		String mName = materialName;
 		String level = "";
-		if (name.contains(":")) {
-		    name = materialName.split(":")[0];
+		if (mName.contains(":")) {
+		    mName = materialName.split(":")[0];
 		    level = ":" + materialName.split(":")[1];
 		}
-		NameList nameInfo = ListOfEnchants.get(name.toLowerCase().replace("_", ""));
+		NameList nameInfo = ListOfEnchants.get(mName.toLowerCase().replace("_", ""));
 		if (nameInfo != null) {
 		    return nameInfo.getMinecraftName() + level;
 		}
-		return materialName;
-	    case CUSTOMKILL:
-	    case EXPLORE:
 		break;
 	    case SHEAR:
 		for (NameList one : ListOfColors) {
 		    String ids = one.getMinecraftName();
-		    if (ids.equalsIgnoreCase(mame)) {
+		    if (ids.equalsIgnoreCase(name)) {
 			return one.getName();
 		    }
 		}
-		break;
+
+		String fallbackColorName = Arrays.stream(name.split("\\s|:|-"))
+		.map(word -> word.substring(0, 1).toUpperCase() + word.substring(1).toLowerCase())
+		.collect(Collectors.joining(" ")); // returns capitalized word (from this -> To This)
+		return fallbackColorName;
 	    case MMKILL:
 		NameList got = ListOfMMEntities.get(materialName.toLowerCase());
 		if (got != null && got.getName() != null)
 		    return got.getName();
 		return HookManager.getMythicManager() == null ? materialName : HookManager.getMythicManager().getDisplayName(materialName);
-	    case BOSS:
-		return HookManager.getBossManager() == null ? materialName : HookManager.getBossManager().getName(materialName);
 	    default:
 		break;
 	    }

--- a/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/NameTranslatorManager.java
@@ -148,6 +148,8 @@ public class NameTranslatorManager {
 		if (got != null && got.getName() != null)
 		    return got.getName();
 		return HookManager.getMythicManager() == null ? materialName : HookManager.getMythicManager().getDisplayName(materialName);
+	    case BOSS:
+		return HookManager.getBossManager() == null ? materialName : HookManager.getBossManager().getName(materialName);
 	    default:
 		break;
 	    }

--- a/src/main/resources/jobConfig.yml
+++ b/src/main/resources/jobConfig.yml
@@ -350,6 +350,7 @@ Jobs:
         income: 5.0
         experience: 10.0
     # Shear sheeps by its color
+    # You can use "color-all" to specify all known colors.
     Shear:
       Black:
         income: 2.0


### PR DESCRIPTION
@montlikadani your first step wasn't bad, I continued by adding the appropiate behaviour for colors in CMIMaterial#getGeneralMaterialName.

I couldn't test it because of dependency problems in your pom.xml, but I'm quite confident that it should work more or less because it works analogous to shullker_box-all. stripped_log-all, tipped_arrow-all, etc. 
Please feel free to test this and to change stuff in code.

You're right, 16 (with income and experience its 48) lines doesn't matter in the jobConfig, but with /jobs info <Jobname> it takes a whole page just with these colors with same income.