### PR TITLE
Improve player inventory item boost logic

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -881,8 +881,8 @@ public class PlayerManager {
 	if (player == null || prog == null)
 	    return data;
 
-	ItemStack iih;
-	List<JobItems> jitems = new ArrayList<>();
+    ItemStack iih;
+    List<JobItems> jitems = new ArrayList<>();
 
     // Check mainhand slot
     if (Jobs.getGCManager().boostedItemsInMainHand) {
@@ -903,22 +903,22 @@ public class PlayerManager {
     }
 
     // Check armor slots
-	if (Jobs.getGCManager().boostedArmorItems) {
-		for (ItemStack oneArmor : player.getInventory().getArmorContents()) {
-			if (oneArmor != null && oneArmor.getType() != org.bukkit.Material.AIR) {
-			    jitems.add(getJobsItemByNbt(oneArmor));
-			}
-		}
-	}
+    if (Jobs.getGCManager().boostedArmorItems) {
+        for (ItemStack oneArmor : player.getInventory().getArmorContents()) {
+            if (oneArmor != null && oneArmor.getType() != org.bukkit.Material.AIR) {
+                jitems.add(getJobsItemByNbt(oneArmor));
+            }
+        }
+    }
 
-	for (JobItems jitem : jitems) {
+    for (JobItems jitem : jitems) {
         if (jitem != null && jitem.getJobs().contains(prog)) {
             data.add(jitem.getBoost(getJobsPlayer(player).getJobProgression(prog)));
         }
     }
 
-	return data;
-    }
+    return data;
+}
 
     public boolean containsItemBoostByNBT(ItemStack item) {
 	return item != null && Jobs.getReflections().hasNbtString(item, JobsItemBoost);

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -905,10 +905,9 @@ public class PlayerManager {
     // Check armor slots
 	if (Jobs.getGCManager().boostedArmorItems) {
 		for (ItemStack oneArmor : player.getInventory().getArmorContents()) {
-			if (oneArmor == null || oneArmor.getType() == org.bukkit.Material.AIR)
-				continue;
-
-			jitems.add(getJobsItemByNbt(oneArmor));
+			if (oneArmor != null && oneArmor.getType() != org.bukkit.Material.AIR) {
+			    jitems.add(getJobsItemByNbt(oneArmor));
+			}
 		}
 	}
 

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -18,33 +18,54 @@
 
 package com.gamingmesh.jobs;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.Sound;
+import org.bukkit.FireworkEffect.Type;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Firework;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Tameable;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.FireworkMeta;
+
+import com.gamingmesh.jobs.CMILib.Version;
 import com.gamingmesh.jobs.CMILib.ActionBarManager;
 import com.gamingmesh.jobs.CMILib.CMIReflections;
 import com.gamingmesh.jobs.CMILib.TitleMessageManager;
-import com.gamingmesh.jobs.CMILib.Version;
 import com.gamingmesh.jobs.api.JobsJoinEvent;
 import com.gamingmesh.jobs.api.JobsLeaveEvent;
 import com.gamingmesh.jobs.api.JobsLevelUpEvent;
-import com.gamingmesh.jobs.container.*;
+import com.gamingmesh.jobs.container.ArchivedJobs;
+import com.gamingmesh.jobs.container.Boost;
+import com.gamingmesh.jobs.container.BoostMultiplier;
+import com.gamingmesh.jobs.container.CurrencyType;
+import com.gamingmesh.jobs.container.ItemBonusCache;
+import com.gamingmesh.jobs.container.Job;
+import com.gamingmesh.jobs.container.JobCommands;
+import com.gamingmesh.jobs.container.JobItems;
+import com.gamingmesh.jobs.container.JobProgression;
+import com.gamingmesh.jobs.container.JobsPlayer;
+import com.gamingmesh.jobs.container.Log;
+import com.gamingmesh.jobs.container.PlayerInfo;
+import com.gamingmesh.jobs.container.PlayerPoints;
 import com.gamingmesh.jobs.dao.JobsDAO;
 import com.gamingmesh.jobs.dao.JobsDAOData;
 import com.gamingmesh.jobs.economy.PaymentData;
 import com.gamingmesh.jobs.hooks.HookManager;
 import com.gamingmesh.jobs.stuff.PerformCommands;
 import com.gamingmesh.jobs.stuff.Util;
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.FireworkEffect;
-import org.bukkit.FireworkEffect.Type;
-import org.bukkit.Sound;
-import org.bukkit.entity.*;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.FireworkMeta;
-
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.regex.Pattern;
 
 public class PlayerManager {
 

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -18,54 +18,33 @@
 
 package com.gamingmesh.jobs;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ThreadLocalRandom;
-import java.util.regex.Pattern;
-
-import org.bukkit.Bukkit;
-import org.bukkit.Color;
-import org.bukkit.FireworkEffect;
-import org.bukkit.Sound;
-import org.bukkit.FireworkEffect.Type;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Firework;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Tameable;
-import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.FireworkMeta;
-
-import com.gamingmesh.jobs.CMILib.Version;
 import com.gamingmesh.jobs.CMILib.ActionBarManager;
 import com.gamingmesh.jobs.CMILib.CMIReflections;
 import com.gamingmesh.jobs.CMILib.TitleMessageManager;
+import com.gamingmesh.jobs.CMILib.Version;
 import com.gamingmesh.jobs.api.JobsJoinEvent;
 import com.gamingmesh.jobs.api.JobsLeaveEvent;
 import com.gamingmesh.jobs.api.JobsLevelUpEvent;
-import com.gamingmesh.jobs.container.ArchivedJobs;
-import com.gamingmesh.jobs.container.Boost;
-import com.gamingmesh.jobs.container.BoostMultiplier;
-import com.gamingmesh.jobs.container.CurrencyType;
-import com.gamingmesh.jobs.container.ItemBonusCache;
-import com.gamingmesh.jobs.container.Job;
-import com.gamingmesh.jobs.container.JobCommands;
-import com.gamingmesh.jobs.container.JobItems;
-import com.gamingmesh.jobs.container.JobProgression;
-import com.gamingmesh.jobs.container.JobsPlayer;
-import com.gamingmesh.jobs.container.Log;
-import com.gamingmesh.jobs.container.PlayerInfo;
-import com.gamingmesh.jobs.container.PlayerPoints;
+import com.gamingmesh.jobs.container.*;
 import com.gamingmesh.jobs.dao.JobsDAO;
 import com.gamingmesh.jobs.dao.JobsDAOData;
 import com.gamingmesh.jobs.economy.PaymentData;
 import com.gamingmesh.jobs.hooks.HookManager;
 import com.gamingmesh.jobs.stuff.PerformCommands;
 import com.gamingmesh.jobs.stuff.Util;
+import org.bukkit.Bukkit;
+import org.bukkit.Color;
+import org.bukkit.FireworkEffect;
+import org.bukkit.FireworkEffect.Type;
+import org.bukkit.Sound;
+import org.bukkit.entity.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.FireworkMeta;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.regex.Pattern;
 
 public class PlayerManager {
 
@@ -881,31 +860,42 @@ public class PlayerManager {
 	if (player == null || prog == null)
 	    return data;
 
-	ItemStack iih = Jobs.getNms().getItemInMainHand(player);
-	JobItems jitem = getJobsItemByNbt(iih);
-	if (jitem != null && jitem.getJobs().contains(prog))
-	    data.add(jitem.getBoost(getJobsPlayer(player).getJobProgression(prog)));
+	ItemStack iih;
+	List<JobItems> jitems = new ArrayList<>();
 
-	// Lets check offhand
-	if (Version.isCurrentEqualOrHigher(Version.v1_9_R1) && Jobs.getGCManager().boostedItemsInOffHand) {
-	    iih = CMIReflections.getItemInOffHand(player);
-	    if (iih != null) {
-		jitem = getJobsItemByNbt(iih);
-		if (jitem != null && jitem.getJobs().contains(prog))
-		    data.add(jitem.getBoost(getJobsPlayer(player).getJobProgression(prog)));
-	    }
+    // Check mainhand slot
+    if (Jobs.getGCManager().boostedItemsInMainHand) {
+        iih = Jobs.getNms().getItemInMainHand(player);
+
+        if (iih != null) {
+            jitems.add(getJobsItemByNbt(iih));
+        }
+    }
+
+    // Check offhand slot
+    if (Version.isCurrentEqualOrHigher(Version.v1_9_R1) && Jobs.getGCManager().boostedItemsInOffHand) {
+        iih = CMIReflections.getItemInOffHand(player);
+
+        if (iih != null) {
+            jitems.add(getJobsItemByNbt(iih));
+        }
+    }
+
+    // Check armor slots
+	if (Jobs.getGCManager().boostedArmorItems) {
+		for (ItemStack oneArmor : player.getInventory().getArmorContents()) {
+			if (oneArmor == null || oneArmor.getType() == org.bukkit.Material.AIR)
+				continue;
+
+			jitems.add(getJobsItemByNbt(oneArmor));
+		}
 	}
 
-	for (ItemStack oneArmor : player.getInventory().getArmorContents()) {
-	    if (oneArmor == null || oneArmor.getType() == org.bukkit.Material.AIR)
-		continue;
-
-	    JobItems armorboost = getJobsItemByNbt(oneArmor);
-	    if (armorboost == null || !armorboost.getJobs().contains(prog))
-		continue;
-
-	    data.add(armorboost.getBoost(getJobsPlayer(player).getJobProgression(prog)));
-	}
+	for (JobItems jitem : jitems) {
+        if (jitem != null && jitem.getJobs().contains(prog)) {
+            data.add(jitem.getBoost(getJobsPlayer(player).getJobProgression(prog)));
+        }
+    }
 
 	return data;
     }

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -451,16 +451,16 @@ public class GeneralConfigManager {
 	c.addComment("add-xp-player", "Adds the Jobs xp received to the player's Minecraft XP bar");
 	addXpPlayer = c.get("add-xp-player", false);
 
-    if (Version.isCurrentEqualOrHigher(Version.v1_9_R1)) {
-        c.addComment("enable-boosted-items-in-offhand", "Do the jobs boost ignore the boosted items usage in off hand?");
-        boostedItemsInOffHand = c.get("enable-boosted-items-in-offhand", true);
-    }
+	if (Version.isCurrentEqualOrHigher(Version.v1_9_R1)) {
+		c.addComment("enable-boosted-items-in-offhand", "Do the jobs boost ignore the boosted items usage in off hand?");
+		boostedItemsInOffHand = c.get("enable-boosted-items-in-offhand", true);
+	}
 
-    c.addComment("enable-boosted-items-in-mainhand", "Do the jobs boost ignore the boosted items usage in main hand?");
-    boostedItemsInMainHand = c.get("enable-boosted-items-in-mainhand", true);
+	c.addComment("enable-boosted-items-in-mainhand", "Do the jobs boost ignore the boosted items usage in main hand?");
+	boostedItemsInMainHand = c.get("enable-boosted-items-in-mainhand", true);
 
-    c.addComment("enable-boosted-armor-items", "Do the jobs boost ignore the boosted items usage in armor slots?");
-    boostedArmorItems = c.get("enable-boosted-armor-items", true);
+	c.addComment("enable-boosted-armor-items", "Do the jobs boost ignore the boosted items usage in armor slots?");
+	boostedArmorItems = c.get("enable-boosted-armor-items", true);
 
 	c.addComment("prevent-crop-resize-payment", "Do you want to prevent crop resizing payment when placing more cactus?",
 	    "This option is only related to: sugar_cane, cactus, kelp, bamboo");

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -451,16 +451,16 @@ public class GeneralConfigManager {
 	c.addComment("add-xp-player", "Adds the Jobs xp received to the player's Minecraft XP bar");
 	addXpPlayer = c.get("add-xp-player", false);
 
-	if (Version.isCurrentEqualOrHigher(Version.v1_9_R1)) {
-	    c.addComment("enable-boosted-items-in-offhand", "Do the jobs boost ignore the boosted items usage in off hand?");
-	    boostedItemsInOffHand = c.get("enable-boosted-items-in-offhand", true);
-	}
+    if (Version.isCurrentEqualOrHigher(Version.v1_9_R1)) {
+        c.addComment("enable-boosted-items-in-offhand", "Do the jobs boost ignore the boosted items usage in off hand?");
+        boostedItemsInOffHand = c.get("enable-boosted-items-in-offhand", true);
+    }
 
-	c.addComment("enable-boosted-items-in-mainhand", "Do the jobs boost ignore the boosted items usage in main hand?");
-	boostedItemsInMainHand = c.get("enable-boosted-items-in-mainhand", true);
+    c.addComment("enable-boosted-items-in-mainhand", "Do the jobs boost ignore the boosted items usage in main hand?");
+    boostedItemsInMainHand = c.get("enable-boosted-items-in-mainhand", true);
 
-	c.addComment("enable-boosted-armor-items", "Do the jobs boost ignore the boosted items usage in armor slots?");
-	boostedArmorItems = c.get("enable-boosted-armor-items", true);
+    c.addComment("enable-boosted-armor-items", "Do the jobs boost ignore the boosted items usage in armor slots?");
+    boostedArmorItems = c.get("enable-boosted-armor-items", true);
 
 	c.addComment("prevent-crop-resize-payment", "Do you want to prevent crop resizing payment when placing more cactus?",
 	    "This option is only related to: sugar_cane, cactus, kelp, bamboo");

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -91,7 +91,7 @@ public class GeneralConfigManager {
 	SignsColorizeJobName, ShowToplistInScoreboard, useGlobalTimer, useSilkTouchProtection, UseCustomNames,
 	PreventSlimeSplit, PreventMagmaCubeSplit, PreventHopperFillUps, PreventBrewingStandFillUps,
 	BrowseUseNewLook, payExploringWhenGliding = false, disablePaymentIfMaxLevelReached, disablePaymentIfRiding,
-	boostedItemsInOffHand = false, preventCropResizePayment, payItemDurabilityLoss,
+	boostedItemsInOffHand = false, boostedItemsInMainHand, boostedArmorItems, preventCropResizePayment, payItemDurabilityLoss,
 	applyToNegativeIncome, useMinimumOveralPayment, useMinimumOveralPoints, useBreederFinder,
 	CancelCowMilking, fixAtMaxLevel, TitleChangeChat, TitleChangeActionBar, LevelChangeChat,
 	LevelChangeActionBar, SoundLevelupUse, SoundTitleChangeUse, UseServerAccount, EmptyServerAccountChat,
@@ -455,6 +455,12 @@ public class GeneralConfigManager {
 	    c.addComment("enable-boosted-items-in-offhand", "Do the jobs boost ignore the boosted items usage in off hand?");
 	    boostedItemsInOffHand = c.get("enable-boosted-items-in-offhand", true);
 	}
+
+	c.addComment("enable-boosted-items-in-mainhand", "Do the jobs boost ignore the boosted items usage in main hand?");
+	boostedItemsInMainHand = c.get("enable-boosted-items-in-mainhand", true);
+
+	c.addComment("enable-boosted-armor-items", "Do the jobs boost ignore the boosted items usage in armor slots?");
+	boostedArmorItems = c.get("enable-boosted-armor-items", true);
 
 	c.addComment("prevent-crop-resize-payment", "Do you want to prevent crop resizing payment when placing more cactus?",
 	    "This option is only related to: sugar_cane, cactus, kelp, bamboo");


### PR DESCRIPTION
This adds two new configuration options to generalConfig. They're modelled after `enable-boosted-items-in-offhand` and called `enable-boosted-items-in-mainhand` and `enable-boosted-armor-items`. As the name suggests, the former determines if boosted items in your main hand count towards your overall jobs items bonus, and the latter does the same for armor. I also cleaned up the logic a bit in `PlayerManager#getInventoryBoost`. If you've got changes, feel free to request edits.