### PR TITLE
Fix a bug with boosted items

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
@@ -718,7 +718,7 @@ public class JobsListener implements Listener {
     }
 
 	@EventHandler
-	public void PlayerSwapHandItemsEvent(PlayerSwapHandItemsEvent event) {
-		Jobs.getPlayerManager().resetiItemBonusCache(event.getPlayer().getUniqueId());
+	public void onPlayerHandSwap(PlayerSwapHandItemsEvent event) {
+	Jobs.getPlayerManager().resetiItemBonusCache(event.getPlayer().getUniqueId());
 	}
 }

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
@@ -58,6 +58,7 @@ import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 import org.bukkit.event.world.WorldLoadEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
@@ -715,4 +716,9 @@ public class JobsListener implements Listener {
     public void PlayerItemBreakEvent(InventoryClickEvent event) {
 	Jobs.getPlayerManager().resetiItemBonusCache(((Player) event.getWhoClicked()).getUniqueId());
     }
+
+	@EventHandler
+	public void PlayerSwapHandItemsEvent(PlayerSwapHandItemsEvent event) {
+		Jobs.getPlayerManager().resetiItemBonusCache(event.getPlayer().getUniqueId());
+	}
 }


### PR DESCRIPTION
Because of #1062, if there's a boosted item in a player's main hand vs. if it's in their offhand matters. Adding a listener for PlayerSwapHandItemsEvent, which is called when a player uses the keybind (defaulted to `F`, called "Swap Items In Hands" under Controls) to swap their hands' items, to invalidate the cache will prevent weird situations where the cached item bonus is incorrect.