### PR TITLE
boost negative income correctly

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/Boost.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Boost.java
@@ -46,7 +46,7 @@ public class Boost {
 	double f = income;
 
 	if (income > 0 || income < 0 && Jobs.getGCManager().applyToNegativeIncome)
-	    f = income + ((income > 0D ? income : -income) * getFinal(BT, false, false));
+	    f = income + income * getFinal(BT, false, false);
 
 	if (income > 0 && f < 0 || income < 0 && f > 0)
 	    f = 0;


### PR DESCRIPTION
This refers to https://github.com/Zrips/Jobs/issues/1099

negative income boost should be calculated the same way just with the boost factor without negating it.