### PR TITLE
Cache entity metadata properly

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -250,8 +250,6 @@ public class JobsPaymentListener implements Listener {
 	if (Jobs.getGCManager().CowMilkingTimer > 0) {
 	    if (cowMilkingTimer.getIfPresent(cowUUID) != null) {
 		long time = cowMilkingTimer.getIfPresent(cowUUID);
-		// If the current time is less than the time when the cow was last milked plus the amount of time
-	        // the player has to wait to milk the cow again, cancel the timer.
 		if (System.currentTimeMillis() < time + Jobs.getGCManager().CowMilkingTimer) {
 		    long timer = ((Jobs.getGCManager().CowMilkingTimer - (System.currentTimeMillis() - time)) / 1000);
 		    jPlayer.getPlayer().sendMessage(Jobs.getLanguage().getMessage("message.cowtimer", "%time%", timer));
@@ -1083,13 +1081,13 @@ public class JobsPaymentListener implements Listener {
 	double s = ((Damageable) ent).getHealth();
 	if (damage > s)
 	    damage = s;
-        if (Jobs.getGCManager().MonsterDamageUse) {
+	if (Jobs.getGCManager().MonsterDamageUse) {
 	    if (damageDealtByPlayers.getIfPresent(entUUID) != null) {
-	    	damageDealtByPlayers.put(entUUID, damageDealtByPlayers.getIfPresent(entUUID) + damage);
+		damageDealtByPlayers.put(entUUID, damageDealtByPlayers.getIfPresent(entUUID) + damage);
 	    } else {
-	    	damageDealtByPlayers.put(entUUID, 0.0);
+		damageDealtByPlayers.put(entUUID, 0.0);
 	    }
-        }
+	}
     }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
@@ -1138,13 +1136,13 @@ public class JobsPaymentListener implements Listener {
 	LivingEntity lVictim = (LivingEntity) e.getEntity();
 	UUID lVictimUUID = lVictim.getUniqueId();
 
-        if (Jobs.getGCManager().MonsterDamageUse && damageDealtByPlayers.getIfPresent(lVictimUUID) != null) {
+	if (Jobs.getGCManager().MonsterDamageUse && damageDealtByPlayers.getIfPresent(lVictimUUID) != null) {
 	    double damage = damageDealtByPlayers.getIfPresent(lVictimUUID);
 	    double perc = (damage * 100D) / Jobs.getNms().getMaxHealth(lVictim);
 	    damageDealtByPlayers.invalidate(lVictimUUID);
 	    if (perc < Jobs.getGCManager().MonsterDamagePercentage)
-	    	return;
-        }
+		return;
+	}
 
 	//extra check for Citizens 2 sentry kills
 	if (e.getDamager() instanceof Player && e.getDamager().hasMetadata("NPC"))

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -95,7 +95,7 @@ public class JobsPaymentListener implements Listener {
 
     private Jobs plugin;
     private final Cache<UUID, Double> damageDealtByPlayers = CacheBuilder.newBuilder()
-		    .expireAfterWrite(10, TimeUnit.MINUTES)
+		    .expireAfterWrite(5, TimeUnit.MINUTES)
 		    .weakKeys()
 		    .build();
     private final Cache<UUID, Entity> punchedEndCrystals = CacheBuilder.newBuilder()
@@ -218,7 +218,6 @@ public class JobsPaymentListener implements Listener {
 	    return;
 
 	Entity cow = event.getRightClicked();
-	UUID cowUUID = cow.getUniqueId();
 	if (cow.getType() != EntityType.COW && cow.getType() != EntityType.MUSHROOM_COW)
 	    return;
 
@@ -248,6 +247,7 @@ public class JobsPaymentListener implements Listener {
 	}
 
 	if (Jobs.getGCManager().CowMilkingTimer > 0) {
+	    UUID cowUUID = cow.getUniqueId();
 	    Long time = cowMilkingTimer.getIfPresent(cowUUID);
 	    if (time != null) {
 		if (System.currentTimeMillis() < time + Jobs.getGCManager().CowMilkingTimer) {
@@ -1070,7 +1070,6 @@ public class JobsPaymentListener implements Listener {
 	    return;
 
 	Entity ent = event.getEntity();
-	UUID entUUID = ent.getUniqueId();
 	if (ent instanceof Player || !(event instanceof EntityDamageByEntityEvent))
 	    return;
 
@@ -1082,6 +1081,7 @@ public class JobsPaymentListener implements Listener {
 	if (damage > s)
 	    damage = s;
 	if (Jobs.getGCManager().MonsterDamageUse) {
+	    UUID entUUID = ent.getUniqueId();
 	    if (damageDealtByPlayers.getIfPresent(entUUID) != null) {
 		damageDealtByPlayers.put(entUUID, damageDealtByPlayers.getIfPresent(entUUID) + damage);
 	    } else {

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -75,6 +75,7 @@ import org.bukkit.event.player.PlayerFishEvent;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerShearEntityEvent;
+import org.bukkit.event.world.ChunkUnloadEvent;
 import org.bukkit.inventory.AnvilInventory;
 import org.bukkit.inventory.EnchantingInventory;
 import org.bukkit.inventory.GrindstoneInventory;
@@ -1137,7 +1138,6 @@ public class JobsPaymentListener implements Listener {
 	UUID lVictimUUID = lVictim.getUniqueId();
 	boolean hadSpawnerMobMetadata = lVictim.hasMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata());
 
-        // mob spawner, no payment or experience
         if (hadSpawnerMobMetadata) {
 	    try {
 	        // So lets remove meta in case some plugin removes entity in wrong way.
@@ -1153,6 +1153,7 @@ public class JobsPaymentListener implements Listener {
 		return;
 	}
 
+	// mob spawner, no payment or experience
 	if (!Jobs.getGCManager().payNearSpawner() && hadSpawnerMobMetadata)
 	    return;
 
@@ -1677,6 +1678,17 @@ public class JobsPaymentListener implements Listener {
 	    return;
 
 	Jobs.action(jPlayer, new ExploreActionInfo(String.valueOf(respond.getCount()), ActionType.EXPLORE));
+    }
+
+    @EventHandler(priority = EventPriority.LOWEST)
+    public void onChunkUnload(ChunkUnloadEvent event) {
+    	for (Entity entity : event.getChunk().getEntities()) {
+	    if (entity.isPersistent())
+	    	return;
+
+	    if (entity.hasMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata()))
+	    	entity.removeMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata(), plugin);
+	}
     }
 
     public static boolean payIfCreative(Player player) {

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -248,8 +248,8 @@ public class JobsPaymentListener implements Listener {
 	}
 
 	if (Jobs.getGCManager().CowMilkingTimer > 0) {
-	    if (cowMilkingTimer.getIfPresent(cowUUID) != null) {
-		long time = cowMilkingTimer.getIfPresent(cowUUID);
+	    Long time = cowMilkingTimer.getIfPresent(cowUUID);
+	    if (time != null) {
 		if (System.currentTimeMillis() < time + Jobs.getGCManager().CowMilkingTimer) {
 		    long timer = ((Jobs.getGCManager().CowMilkingTimer - (System.currentTimeMillis() - time)) / 1000);
 		    jPlayer.getPlayer().sendMessage(Jobs.getLanguage().getMessage("message.cowtimer", "%time%", timer));

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1135,6 +1135,15 @@ public class JobsPaymentListener implements Listener {
 
 	LivingEntity lVictim = (LivingEntity) e.getEntity();
 	UUID lVictimUUID = lVictim.getUniqueId();
+	boolean hadSpawnerMobMetadata = lVictim.hasMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata());
+
+        // mob spawner, no payment or experience
+        if (hadSpawnerMobMetadata) {
+	    try {
+	        // So lets remove meta in case some plugin removes entity in wrong way.
+	        lVictim.removeMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata(), plugin);
+	    } catch (Exception ignored) { }
+        }
 
 	if (Jobs.getGCManager().MonsterDamageUse && damageDealtByPlayers.getIfPresent(lVictimUUID) != null) {
 	    double damage = damageDealtByPlayers.getIfPresent(lVictimUUID);
@@ -1144,22 +1153,15 @@ public class JobsPaymentListener implements Listener {
 		return;
 	}
 
+	if (!Jobs.getGCManager().payNearSpawner() && hadSpawnerMobMetadata)
+	    return;
+
 	//extra check for Citizens 2 sentry kills
 	if (e.getDamager() instanceof Player && e.getDamager().hasMetadata("NPC"))
 	    return;
 
 	if (Jobs.getGCManager().MythicMobsEnabled && HookManager.getMythicManager() != null
 	    && HookManager.getMythicManager().isMythicMob(lVictim)) {
-	    return;
-	}
-
-	// mob spawner, no payment or experience
-	if (lVictim.hasMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata()) && !Jobs.getGCManager().payNearSpawner()) {
-	    try {
-		// So lets remove meta in case some plugin removes entity in wrong way.
-		lVictim.removeMetadata(Jobs.getPlayerManager().getMobSpawnerMetadata(), plugin);
-	    } catch (Exception t) {
-	    }
 	    return;
 	}
 

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -259,7 +259,7 @@ public class JobsPaymentListener implements Listener {
 		    return;
 		}
 	    } else {
-	    	cowMilkingTimer.put(cowUUID, System.currentTimeMillis());
+		cowMilkingTimer.put(cowUUID, System.currentTimeMillis());
 	    }
 	}
 


### PR DESCRIPTION
This fixes #1053 by replacing the previous entity metadata system with a proper caching system for tracking how much damage players have inflicted on mobs, how long since a cow has been milked, and if an end crystal's explosion was caused by a player. 

I'm marking this as a draft because I might implement a similar system for the block ownership system, and I'm not sure if the current changes are breaking (some help testing would be appreciated).