### PR TITLE
Add reverse world blacklist system

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1148,7 +1148,7 @@ public class ConfigManager {
 	    job.setBossbar(bossbar);
 	    job.setRejoinCd(rejoinCd);
 	    job.setMaxLevelCommands(jobSection.getStringList("commands-on-max-level"));
-	    job.setReversedBlacklistFunctionality(jobSection.getBoolean("reverse-world-blacklist-functionality"));
+	    job.setReversedWorldBlacklist(jobSection.getBoolean("reverse-world-blacklist-functionality"));
 
 	    if (jobSection.isConfigurationSection("Quests")) {
 		List<Quest> quests = new ArrayList<>();

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1148,6 +1148,7 @@ public class ConfigManager {
 	    job.setBossbar(bossbar);
 	    job.setRejoinCd(rejoinCd);
 	    job.setMaxLevelCommands(jobSection.getStringList("commands-on-max-level"));
+	    job.setReversedBlacklistFunctionality(jobSection.getBoolean("reverse-world-blacklist-functionality", false));
 
 	    if (jobSection.isConfigurationSection("Quests")) {
 		List<Quest> quests = new ArrayList<>();

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1148,7 +1148,7 @@ public class ConfigManager {
 	    job.setBossbar(bossbar);
 	    job.setRejoinCd(rejoinCd);
 	    job.setMaxLevelCommands(jobSection.getStringList("commands-on-max-level"));
-	    job.setReversedBlacklistFunctionality(jobSection.getBoolean("reverse-world-blacklist-functionality", false));
+	    job.setReversedBlacklistFunctionality(jobSection.getBoolean("reverse-world-blacklist-functionality"));
 
 	    if (jobSection.isConfigurationSection("Quests")) {
 		List<Quest> quests = new ArrayList<>();

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -650,7 +650,7 @@ public class Job {
         if (block != null)
             return worldBlacklist.contains(block.getWorld().getName()) != isReversedWorldBlacklist();
 
-        return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != isReversedWorldBlacklist();
+        return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != reversedWorldBlacklist;
     }
 
     public boolean isReversedWorldBlacklist() {

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -86,6 +86,7 @@ public class Job {
 
     private final List<String> fDescription = new ArrayList<>(), maxLevelCommands = new ArrayList<>();
     private List<String> worldBlacklist = new ArrayList<>();
+    private boolean reversedBlacklistFunctionality = false;
 
     private final List<Quest> quests = new ArrayList<>();
     private int maxDailyQuests = 1;
@@ -643,17 +644,25 @@ public class Job {
     }
 
     public boolean isWorldBlackListed(Block block, Entity ent) {
-	if (worldBlacklist.isEmpty())
-	    return false;
+        if (worldBlacklist.isEmpty())
+            return isReversedBlacklistFunctionality();
 
-	if (block != null && worldBlacklist.contains(block.getWorld().getName()))
-	    return true;
+        if (block != null)
+            return worldBlacklist.contains(block.getWorld().getName()) != isReversedBlacklistFunctionality();
 
-	return ent != null && worldBlacklist.contains(ent.getWorld().getName());
+        return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != isReversedBlacklistFunctionality();
+    }
+
+    public boolean isReversedBlacklistFunctionality() {
+        return reversedBlacklistFunctionality;
+    }
+
+    public void setReversedBlacklistFunctionality(boolean reversedBlacklistFunctionality) {
+        this.reversedBlacklistFunctionality = reversedBlacklistFunctionality;
     }
 
     @Override
     public boolean equals(Object obj) {
-	return obj instanceof Job ? isSame((Job) obj) : false;
+        return obj instanceof Job && isSame((Job) obj);
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -648,7 +648,7 @@ public class Job {
             return isReversedWorldBlacklist();
 
         if (block != null)
-            return worldBlacklist.contains(block.getWorld().getName()) != isReversedWorldBlacklist();
+            return worldBlacklist.contains(block.getWorld().getName()) != reversedWorldBlacklist;
 
         return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != reversedWorldBlacklist;
     }

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -86,7 +86,7 @@ public class Job {
 
     private final List<String> fDescription = new ArrayList<>(), maxLevelCommands = new ArrayList<>();
     private List<String> worldBlacklist = new ArrayList<>();
-    private boolean reversedBlacklistFunctionality = false;
+    private boolean reversedWorldBlacklist = false;
 
     private final List<Quest> quests = new ArrayList<>();
     private int maxDailyQuests = 1;
@@ -645,20 +645,20 @@ public class Job {
 
     public boolean isWorldBlackListed(Block block, Entity ent) {
         if (worldBlacklist.isEmpty())
-            return isReversedBlacklistFunctionality();
+            return isReversedWorldBlacklist();
 
         if (block != null)
-            return worldBlacklist.contains(block.getWorld().getName()) != isReversedBlacklistFunctionality();
+            return worldBlacklist.contains(block.getWorld().getName()) != isReversedWorldBlacklist();
 
-        return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != isReversedBlacklistFunctionality();
+        return ent != null && worldBlacklist.contains(ent.getWorld().getName()) != isReversedWorldBlacklist();
     }
 
-    public boolean isReversedBlacklistFunctionality() {
-        return reversedBlacklistFunctionality;
+    public boolean isReversedWorldBlacklist() {
+        return reversedWorldBlacklist;
     }
 
-    public void setReversedBlacklistFunctionality(boolean reversedBlacklistFunctionality) {
-        this.reversedBlacklistFunctionality = reversedBlacklistFunctionality;
+    public void setReversedWorldBlacklist(boolean reversedWorldBlacklist) {
+        this.reversedWorldBlacklist = reversedWorldBlacklist;
     }
 
     @Override

--- a/src/main/resources/jobs/_EXAMPLE.yml
+++ b/src/main/resources/jobs/_EXAMPLE.yml
@@ -575,7 +575,10 @@ exampleJob:
   commands-on-max-level:
   - 'msg [playerName] Max level of [job] reached!'
   - 'player:jobs stats'
-
+  
+  # Turns the "world-blacklist" list into a whitelist. This essentially means the job only works in the specified worlds.
+  reverse-world-blacklist-functionality: false
+  
   # World list in which this job will not work. World name should be exact
   world-blacklist:
   - plotworld

--- a/src/main/resources/jobs/_EXAMPLE.yml
+++ b/src/main/resources/jobs/_EXAMPLE.yml
@@ -3,7 +3,7 @@
 # Edited by roracle to include 1.13 items and item names, preparing for 1.14 as well.
 
 # ATTENTION!
-# This is just an example job and will not be included into job list. Recomended to keep
+# This is just an example job and will not be included into job list. Recommended to keep
 # it around just for reference. Can be removed if needed.
 
 # Must be one word. This job will be ignored as this is just example of all possible actions.


### PR DESCRIPTION
Adds `reverse-world-blacklist-functionality: false` job config feature.

This system allows a job to function only in specific worlds. E.g.
```yaml
  #(Result: Prevents job in mainworld) - default
  reverse-world-blacklist-functionality: false
  world-blacklist:
  - mainworld
```
```yaml
  #(Result: Only allows job in mainworld)
  reverse-world-blacklist-functionality: true
  world-blacklist:
  - mainworld
```