### PR TITLE
Add ignore-job-max config section

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/join.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/join.java
@@ -65,7 +65,7 @@ public class join implements Cmd {
 	    return true;
 	}
 
-	if (!Jobs.getPlayerManager().getJobsLimit(jPlayer, (short) jPlayer.progression.size())) {
+	if (!job.isIgnoreMaxJobs() && !Jobs.getPlayerManager().getJobsLimit(jPlayer, (short) jPlayer.progression.size())) {
 	    pSender.sendMessage(Jobs.getLanguage().getMessage("command.join.error.maxjobs"));
 	    return true;
 	}

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1148,7 +1148,7 @@ public class ConfigManager {
 	    job.setBossbar(bossbar);
 	    job.setRejoinCd(rejoinCd);
 	    job.setMaxLevelCommands(jobSection.getStringList("commands-on-max-level"));
-            job.setIgnoreMaxJobs(jobSection.getBoolean("ignore-jobs-max", false));
+	    job.setIgnoreMaxJobs(jobSection.getBoolean("ignore-jobs-max"));
 
 	    if (jobSection.isConfigurationSection("Quests")) {
 		List<Quest> quests = new ArrayList<>();

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -1148,6 +1148,7 @@ public class ConfigManager {
 	    job.setBossbar(bossbar);
 	    job.setRejoinCd(rejoinCd);
 	    job.setMaxLevelCommands(jobSection.getStringList("commands-on-max-level"));
+            job.setIgnoreMaxJobs(jobSection.getBoolean("ignore-jobs-max", false));
 
 	    if (jobSection.isConfigurationSection("Quests")) {
 		List<Quest> quests = new ArrayList<>();

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -90,6 +90,7 @@ public class Job {
     private final List<Quest> quests = new ArrayList<>();
     private int maxDailyQuests = 1;
     private int id = 0;
+    private boolean ignoreMaxJobs = false;
 
     @Deprecated
     public Job(String jobName, String fullName, String jobShortName, String description, CMIChatColor jobColour, Parser maxExpEquation, DisplayMethod displayMethod, int maxLevel,
@@ -650,6 +651,14 @@ public class Job {
 	    return true;
 
 	return ent != null && worldBlacklist.contains(ent.getWorld().getName());
+    }
+
+    public boolean isIgnoreMaxJobs() {
+        return ignoreMaxJobs;
+    }
+
+    public void setIgnoreMaxJobs(boolean ignoreMaxJobs) {
+        this.ignoreMaxJobs = ignoreMaxJobs;
     }
 
     @Override

--- a/src/main/resources/jobs/_EXAMPLE.yml
+++ b/src/main/resources/jobs/_EXAMPLE.yml
@@ -581,6 +581,8 @@ exampleJob:
   - plotworld
   - teamworld
 
+  #Allow a player to "/jobs join" this job even if they have the max jobs permission reached.
+  ignore-jobs-max: false
   # Limit item use to jobs level
   limitedItems:
     # Just name, don't have any impact

--- a/src/main/resources/jobs/_EXAMPLE.yml
+++ b/src/main/resources/jobs/_EXAMPLE.yml
@@ -581,8 +581,9 @@ exampleJob:
   - plotworld
   - teamworld
 
-  #Allow a player to "/jobs join" this job even if they have the max jobs permission reached.
+  # Allow a player to "/jobs join" this job even if they have the max jobs permission reached.
   ignore-jobs-max: false
+  
   # Limit item use to jobs level
   limitedItems:
     # Just name, don't have any impact


### PR DESCRIPTION
This feature gives allows a job to ignore the max job limit (if specified in the config). The use-case for this is if a server-owner wants a job to always be joinable even if the max is met.