### PR TITLE
Fix stripping warped/crimson stems not counting for the StripLogs action

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1635,8 +1635,8 @@ public class JobsPaymentListener implements Listener {
 
 		// either it's version 1.13+ and we're trying to strip a normal log like oak,
 		// or it's 1.16+ and we're trying to strip a fungi like warped stem
-		if ((Version.isCurrentEqualOrHigher(Version.v1_13_R1) && block.getType().toString().endsWith("_LOG")) ||
-		    (Version.isCurrentEqualOrHigher(Version.v1_16_R1) && block.getType().toString().endsWith("_STEM")))
+		if ((Version.isCurrentEqualOrHigher(Version.v1_13_R1) && (block.getType().toString().endsWith("_LOG") || block.getType().toString().endsWith("_WOOD"))) ||
+		    (Version.isCurrentEqualOrHigher(Version.v1_16_R1) && (block.getType().toString().endsWith("_STEM") || block.getType().toString().endsWith("_HYPHAE"))))
 			Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> Jobs.action(jPlayer, new BlockActionInfo(block, ActionType.STRIPLOGS), block), 1);
 	}
     }

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1622,8 +1622,7 @@ public class JobsPaymentListener implements Listener {
 		    "[current]", blockOwner.getTotal(jPlayer.getUniqueId()),
 		    "[max]", jPlayer.getMaxOwnerShipAllowed(blockOwner.getType()) == 0 ? "-" : jPlayer.getMaxOwnerShipAllowed(blockOwner.getType())));
 	    }
-	} else if (Version.isCurrentEqualOrHigher(Version.v1_13_R1) &&
-	    !block.getType().toString().startsWith("STRIPPED_") && block.getType().toString().endsWith("_LOG") &&
+	} else if (!block.getType().toString().startsWith("STRIPPED_") &&
 	    event.getAction() == Action.RIGHT_CLICK_BLOCK && jPlayer != null && hand.toString().endsWith("_AXE")) {
 	    // check if player is riding
 	    if (Jobs.getGCManager().disablePaymentIfRiding && p.isInsideVehicle())
@@ -1634,7 +1633,11 @@ public class JobsPaymentListener implements Listener {
 		- Jobs.getNms().getDurability(Jobs.getNms().getItemInMainHand(p)) != hand.getMaxDurability())
 		return;
 
-	    Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> Jobs.action(jPlayer, new BlockActionInfo(block, ActionType.STRIPLOGS), block), 1);
+		// either it's version 1.13+ and we're trying to strip a normal log like oak,
+		// or it's 1.16+ and we're trying to strip a fungi like warped stem
+		if ((Version.isCurrentEqualOrHigher(Version.v1_13_R1) && block.getType().toString().endsWith("_LOG")) ||
+		    (Version.isCurrentEqualOrHigher(Version.v1_16_R1) && block.getType().toString().endsWith("_STEM")))
+			Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, () -> Jobs.action(jPlayer, new BlockActionInfo(block, ActionType.STRIPLOGS), block), 1);
 	}
     }
 


### PR DESCRIPTION
This fixes #1176 by changing how the check for the `StripLogs` action happens. Instead of only firing the action if the version is 1.13+ and the block's type name ends with `_LOG`, the action will now also fire if the version is 1.16+ and the block's type name ends with `_STEM`.