### PR TITLE
Changed the event process level for BlockBreakEvent to HIGHEST

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -362,7 +362,7 @@ public class JobsPaymentListener implements Listener {
 	    Jobs.action(jPlayer, new ItemActionInfo(contents, ActionType.BREW));
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.HIGHEST)
     public void onBlockBreak(BlockBreakEvent event) {
 	final Block block = event.getBlock();
 


### PR DESCRIPTION
Changed the event process level from MONITOR to HIGHEST so that other plugins can process BlockBreakEvent after Jobs.