### PR TITLE
Resolve Enchantment Name Matching

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1002,7 +1002,7 @@ public final class JobsPaymentListener implements Listener {
 	    String enchantName = null;
 
 	    try {
-		enchantName = enchant.getKey().getKey().toLowerCase().replace("_", "").replace("minecraft:", "");
+		enchantName = enchant.getKey().getKey().toLowerCase().replace("minecraft:", "");
 	    } catch (Throwable e) {
 		CMIEnchantment ench = CMIEnchantment.get(enchant);
 		if (ench != null)


### PR DESCRIPTION
Stripping underscores here meant enchantments would never match if their equivalent in CMIEnchantment had an underscore in the name as that is what the config is ultimately parsed as.

e.g. Having an enchant such as `water_worker` which is translated to `AQUA_AFFINITY` in `jobInfo` would fail to match as it is compared against the stripped `enchantName` of `aquaaffinity`.

My primary concern is that this could break "custom enchants" as the change was initially made for in a451653