### PR TITLE
Enchantment Fixes

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/actions/EnchantActionInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/EnchantActionInfo.java
@@ -40,4 +40,8 @@ public class EnchantActionInfo extends BaseActionInfo {
 	public String getNameWithSub() {
 		return name + ":" + level;
 	}
+
+	public int getLevel() {
+		return level;
+	}
 }

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.BiPredicate;
 
-import com.gamingmesh.jobs.CMILib.CMIEnchantment;
 import com.gamingmesh.jobs.actions.EnchantActionInfo;
+import com.gamingmesh.jobs.stuff.Util;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -310,16 +310,7 @@ public class Job {
 	    }
 
 	    if (actionInfo instanceof EnchantActionInfo) {
-		EnchantActionInfo enchantActionInfo = (EnchantActionInfo)actionInfo;
-
-		String enchantName = CMIEnchantment.get(actionInfo.getName()).toString();
-
-		return (
-		    // Enchantment without level e.g. silk_touch
-		    jobInfo.getName().equalsIgnoreCase(enchantName) ||
-		    // Enchantment with level e.g. fire_aspect:1
-		    jobInfo.getName().equalsIgnoreCase(enchantName + ":" + enchantActionInfo.getLevel())
-		);
+		return Util.enchantMatchesActionInfo(jobInfo.getName(), (EnchantActionInfo) actionInfo);
 	    }
 
 	    return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.Random;
 import java.util.function.BiPredicate;
 
+import com.gamingmesh.jobs.CMILib.CMIEnchantment;
+import com.gamingmesh.jobs.actions.EnchantActionInfo;
 import org.bukkit.block.Block;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Entity;
@@ -305,6 +307,19 @@ public class Job {
 	    if (actionInfo instanceof PotionItemActionInfo) {
 		String subName = ((PotionItemActionInfo) action).getNameWithSub();
 		return jobInfo.getName().equalsIgnoreCase(subName) || (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(subName);
+	    }
+
+	    if (actionInfo instanceof EnchantActionInfo) {
+		EnchantActionInfo enchantActionInfo = (EnchantActionInfo)actionInfo;
+
+		String enchantName = CMIEnchantment.get(actionInfo.getName()).toString();
+
+		return (
+		    // Enchantment without level e.g. silk_touch
+		    jobInfo.getName().equalsIgnoreCase(enchantName) ||
+		    // Enchantment with level e.g. fire_aspect:1
+		    jobInfo.getName().equalsIgnoreCase(enchantName + ":" + enchantActionInfo.getLevel())
+		);
 	    }
 
 	    return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -964,7 +964,9 @@ public final class JobsPaymentListener implements Listener {
 	ItemStack secondSlotItem = inv.getItem(1);
 
 	if (Jobs.getGCManager().PayForEnchantingOnAnvil && secondSlotItem != null && secondSlotItem.getType() == Material.ENCHANTED_BOOK) {
-	    for (Map.Entry<Enchantment, Integer> oneEnchant : resultStack.getEnchantments().entrySet()) {
+	    Map<Enchantment, Integer> newEnchantments = Util.mapUnique(resultStack.getEnchantments(), firstSlot.getEnchantments());
+
+	    for (Map.Entry<Enchantment, Integer> oneEnchant : newEnchantments.entrySet()) {
 		Enchantment enchant = oneEnchant.getKey();
 		if (enchant == null)
 		    continue;

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -840,6 +840,19 @@ public final class JobsPaymentListener implements Listener {
 	return a.getAmount() + b.getAmount() <= a.getType().getMaxStackSize();
     }
 
+    private static String getEnchantName(Enchantment enchant) {
+	try {
+	    return enchant.getKey().getKey().toLowerCase().replace("_", "").replace("minecraft:", "");
+
+	} catch (Throwable e) {
+	    CMIEnchantment cmiEnchant = CMIEnchantment.get(enchant);
+	    if (cmiEnchant != null)
+		return cmiEnchant.toString();
+	}
+
+	return null;
+    }
+
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onInventoryRepair(InventoryClickEvent event) {
 	// If event is nothing or place, do nothing
@@ -956,9 +969,9 @@ public final class JobsPaymentListener implements Listener {
 		if (enchant == null)
 		    continue;
 
-		CMIEnchantment e = CMIEnchantment.get(enchant);
-		if (e != null)
-		    Jobs.action(jPlayer, new EnchantActionInfo(e.toString(), oneEnchant.getValue(), ActionType.ENCHANT));
+		String enchantName = getEnchantName(enchant);
+		if (enchantName != null)
+		    Jobs.action(jPlayer, new EnchantActionInfo(enchantName, oneEnchant.getValue(), ActionType.ENCHANT));
 	    }
 	} else if (secondSlotItem == null || secondSlotItem.getType() != Material.ENCHANTED_BOOK) // Enchanted books does not have durability
 	    Jobs.action(jPlayer, new ItemActionInfo(resultStack, ActionType.REPAIR));
@@ -1013,16 +1026,7 @@ public final class JobsPaymentListener implements Listener {
 	    if (enchant == null)
 		continue;
 
-	    String enchantName = null;
-
-	    try {
-		enchantName = enchant.getKey().getKey().toLowerCase().replace("_", "").replace("minecraft:", "");
-	    } catch (Throwable e) {
-		CMIEnchantment ench = CMIEnchantment.get(enchant);
-		if (ench != null)
-		    enchantName = ench.toString();
-	    }
-
+	    String enchantName = getEnchantName(enchant);
 	    if (enchantName != null)
 		Jobs.action(jPlayer, new EnchantActionInfo(enchantName, oneEnchant.getValue(), ActionType.ENCHANT));
 	}

--- a/src/main/java/com/gamingmesh/jobs/stuff/Util.java
+++ b/src/main/java/com/gamingmesh/jobs/stuff/Util.java
@@ -395,4 +395,14 @@ public final class Util {
 
 	return listOfCommands;
     }
+
+    public static <K, V> Map<K, V> mapUnique(Map<K, V> left, Map<K, V> right) {
+	Map<K, V> difference = new HashMap<>();
+
+	difference.putAll(left);
+	difference.putAll(right);
+	difference.entrySet().removeAll(right.entrySet());
+
+	return difference;
+    }
 }

--- a/src/main/java/com/gamingmesh/jobs/stuff/Util.java
+++ b/src/main/java/com/gamingmesh/jobs/stuff/Util.java
@@ -14,6 +14,8 @@ import java.util.UUID;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
 
+import com.gamingmesh.jobs.CMILib.CMIEnchantment;
+import com.gamingmesh.jobs.actions.EnchantActionInfo;
 import org.bukkit.Bukkit;
 import org.bukkit.Color;
 import org.bukkit.Location;
@@ -404,5 +406,16 @@ public final class Util {
 	difference.entrySet().removeAll(right.entrySet());
 
 	return difference;
+    }
+
+    public static boolean enchantMatchesActionInfo(String enchant, EnchantActionInfo actionInfo) {
+	String enchantName = CMIEnchantment.get(actionInfo.getName()).toString();
+
+	return (
+	    // Enchantment without level e.g. silk_touch
+	    enchant.equalsIgnoreCase(enchantName) ||
+	    // Enchantment with level e.g. fire_aspect:1
+	    enchant.equalsIgnoreCase(enchantName + ":" + actionInfo.getLevel())
+	);
     }
 }


### PR DESCRIPTION
Supersedes #1262

Fixes the following enchanting issues:
1. Enchantments with underscores not matching in direct string comparisons for job payment
2. Being paid for existing enchantments on an item when adding new ones with a book on an anvil
3. Quest enchantment objective detection being overly specific and case sensitive (unlike job tasks)