### PR TITLE
Fix for #1290

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -566,7 +566,8 @@ public class Job {
 
 	if (fDescription != null) {
 	    this.fDescription.addAll(fDescription);
-	}
+        this.description = String.join("\n",this.fDescription);
+    }
     }
 
     public void setMaxLevelCommands(List<String> commands) {


### PR DESCRIPTION
The Description PlaceHolder is deprecated but it still shoud work, as it is the only placeholder available for that.

This pull request fix https://github.com/Zrips/Jobs/issues/1290.

