### PR TITLE
Fix WildStacker integration

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/hooks/wildStacker/WildStackerHandler.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/wildStacker/WildStackerHandler.java
@@ -1,7 +1,5 @@
 package com.gamingmesh.jobs.hooks.wildStacker;
 
-import java.util.List;
-
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 
@@ -10,13 +8,17 @@ import com.bgsoftware.wildstacker.api.objects.StackedEntity;
 
 public class WildStackerHandler {
 
-    public boolean isStackedEntity(LivingEntity entity) {
-	if (entity instanceof Player)
-	    return false;
-	return WildStackerAPI.getStackedEntity(entity) != null;
-    }
+    public int getEntityAmount(LivingEntity entity) {
 
-    public List<StackedEntity> getStackedEntities() {
-	return WildStackerAPI.getWildStacker().getSystemManager().getStackedEntities();
+        if (entity instanceof Player)
+            return 0;
+
+        StackedEntity stacked = WildStackerAPI.getStackedEntity(entity);
+
+        if(stacked == null) {
+            return 0;
+        }
+
+        return stacked.getStackAmount();
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.bgsoftware.wildstacker.api.enums.StackSplit;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -125,7 +126,6 @@ import net.Zrips.CMILib.Container.CMILocation;
 import net.Zrips.CMILib.Entities.CMIEntityType;
 import net.Zrips.CMILib.Items.CMIItemStack;
 import net.Zrips.CMILib.Items.CMIMaterial;
-import net.Zrips.CMILib.Logs.CMIDebug;
 import net.Zrips.CMILib.Version.Version;
 
 public final class JobsPaymentListener implements Listener {
@@ -336,12 +336,10 @@ public final class JobsPaymentListener implements Listener {
 	    return;
 
 	if (Jobs.getGCManager().payForStackedEntities) {
-	    if (JobsHook.WildStacker.isEnabled() && HookManager.getWildStackerHandler().isStackedEntity(sheep)) {
-		for (com.bgsoftware.wildstacker.api.objects.StackedEntity stacked : HookManager.getWildStackerHandler().getStackedEntities()) {
-		    if (stacked.getType() == sheep.getType()) {
-			Jobs.action(jDamager, new CustomKillInfo(((Sheep) stacked.getLivingEntity()).getColor().name(), ActionType.SHEAR));
-		    }
-		}
+	    if (JobsHook.WildStacker.isEnabled() && !StackSplit.SHEEP_SHEAR.isEnabled()) {
+			for(int i = 0; i < HookManager.getWildStackerHandler().getEntityAmount(sheep) - 1; i++) {
+				Jobs.action(jDamager, new CustomKillInfo(sheep.getColor().name(), ActionType.SHEAR));
+			}
 	    } else if (JobsHook.StackMob.isEnabled() && HookManager.getStackMobHandler().isStacked(sheep)) {
 		for (uk.antiperson.stackmob.entity.StackEntity stacked : HookManager.getStackMobHandler().getStackEntities()) {
 		    if (stacked.getEntity().getType() == sheep.getType()) {
@@ -588,11 +586,9 @@ public final class JobsPaymentListener implements Listener {
 	    return;
 
 	if (Jobs.getGCManager().payForStackedEntities) {
-	    if (JobsHook.WildStacker.isEnabled() && HookManager.getWildStackerHandler().isStackedEntity(animal)) {
-		for (com.bgsoftware.wildstacker.api.objects.StackedEntity stacked : HookManager.getWildStackerHandler().getStackedEntities()) {
-		    if (stacked.getType() == animal.getType()) {
-			Jobs.action(jDamager, new EntityActionInfo(stacked.getLivingEntity(), ActionType.TAME));
-		    }
+	    if (JobsHook.WildStacker.isEnabled()) {
+		for (int i = 0; i < HookManager.getWildStackerHandler().getEntityAmount(animal) - 1; i++) {
+			Jobs.action(jDamager, new EntityActionInfo(animal, ActionType.TAME));
 		}
 	    } else if (JobsHook.StackMob.isEnabled() && HookManager.getStackMobHandler().isStacked(animal)) {
 		for (uk.antiperson.stackmob.entity.StackEntity stacked : HookManager.getStackMobHandler().getStackEntities()) {
@@ -1332,11 +1328,9 @@ public final class JobsPaymentListener implements Listener {
 	    return;
 
 	if (Jobs.getGCManager().payForStackedEntities) {
-	    if (JobsHook.WildStacker.isEnabled() && HookManager.getWildStackerHandler().isStackedEntity(lVictim)) {
-		for (com.bgsoftware.wildstacker.api.objects.StackedEntity stacked : HookManager.getWildStackerHandler().getStackedEntities()) {
-		    if (stacked.getType() == lVictim.getType()) {
-			Jobs.action(jDamager, new EntityActionInfo(stacked.getLivingEntity(), ActionType.KILL), e.getDamager(), stacked.getLivingEntity());
-		    }
+	    if (JobsHook.WildStacker.isEnabled()) {
+		for (int i = 0; i < HookManager.getWildStackerHandler().getEntityAmount(lVictim) - 1; i++) {
+			Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), e.getDamager(), lVictim);
 		}
 	    } else if (JobsHook.StackMob.isEnabled() && HookManager.getStackMobHandler().isStacked(lVictim)) {
 		for (uk.antiperson.stackmob.entity.StackEntity stacked : HookManager.getStackMobHandler().getStackEntities()) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -6,7 +6,7 @@ api-version: "1.13"
 website: https://www.spigotmc.org/resources/4216/
 authors: [Zrips, montlikadani]
 depend: [CMILib]
-softdepend: [Vault, Essentials, MythicMobs, McMMO, mcMMO, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants]
+softdepend: [Vault, Essentials, MythicMobs, McMMO, mcMMO, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, StackMob]
 commands:
   jobs:
     description: Jobs


### PR DESCRIPTION
Hello,

I found 2 problems with the WildStacker integration and I fixed them:
- Wildstacker and StackMob started after jobs because they were not specified in the plugin dependencies.
- The number of entities taken into account when WildStacker was enabled was the number of entities of the same type as the targeted entity in WildStacker, not the number of entities stacked in the targeted entity.