### PR TITLE
ExploreRegion: Fix encoding X and Z

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/ExploreRegion.java
+++ b/src/main/java/com/gamingmesh/jobs/container/ExploreRegion.java
@@ -10,66 +10,46 @@ public class ExploreRegion {
     int x;
     int z;
 
-    private final Map<Short, ExploreChunk> chunks = new HashMap<>();
+    private final Map<Long, ExploreChunk> chunks = new HashMap<>();
 
     public ExploreRegion(int x, int z) {
-	this.x = x;
-	this.z = z;
+        this.x = x;
+        this.z = z;
     }
 
     public void addChunk(int x, int z, ExploreChunk chunk) {
-	chunks.put(getPlace(x, z), chunk);
+        chunks.put(getPlace(x, z), chunk);
     }
 
-    public Map<Short, ExploreChunk> getChunks() {
-	return chunks;
+    public Map<Long, ExploreChunk> getChunks() {
+        return chunks;
     }
 
     public ExploreChunk getChunk(int x, int z) {
-	return getChunk(getPlace(x, z));
+        return getChunk(getPlace(x, z));
     }
 
     public ExploreChunk getChunk(Chunk chunk) {
-	return getChunk(getPlace(chunk));
+        return getChunk(getPlace(chunk));
     }
 
-    public ExploreChunk getChunk(short place) {
-	return chunks.get(place);
+    public ExploreChunk getChunk(long place) {
+        return chunks.get(place);
     }
 
-    private static short getPlace(Chunk chunk) {
-	return getPlace(chunk.getX(), chunk.getZ());
+    private static long getPlace(Chunk chunk) {
+        return getPlace(chunk.getX(), chunk.getZ());
     }
 
-    private static short getPlace(int x, int z) {
-	return (short) ((x - ((x >> 5) * 32)) + ((z - ((z >> 5) * 32)) * 32));
+    private static long getPlace(int x, int z) {
+        return (((long) x) << 32) | (z & 0xffffffff);
     }
 
-    public int getChunkX(short place) {
-	int endX = place % 32;
-
-	if (x < 0)
-	    endX = -endX;
-
-	endX = x * 32 + endX;
-
-	if (endX < 0) {
-	    endX += 32;
-	}
-
-	return endX;
+    public int getChunkX(long place) {
+        return (int)(place >> 32);
     }
 
-    public int getChunkZ(short place) {
-	int endZ = (place - (place % 32)) / 32;
-	if (z < 0)
-	    endZ = -endZ;
-	endZ = z * 32 + endZ;
-
-	if (endZ < 0) {
-	    endZ += 32;
-	}
-
-	return endZ;
+    public int getChunkZ(long place) {
+        return (int) place;
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
+++ b/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
@@ -1542,7 +1542,7 @@ public abstract class JobsDAO {
      * Join a job (create player-job entry from storage)
      * @param player - player that wishes to join the job
      * @param job - job that the player wishes to join
-     * @throws SQLException 
+     * @throws SQLException
      */
     public List<Convert> convertDatabase() throws SQLException {
 	List<Convert> list = new ArrayList<>();
@@ -2466,7 +2466,7 @@ public abstract class JobsDAO {
 
 		    int id = jobsWorld == null ? 0 : jobsWorld.getId();
 		    if (id != 0)
-			for (Entry<Short, ExploreChunk> oneChunk : region.getValue().getChunks().entrySet()) {
+			for (Entry<Long, ExploreChunk> oneChunk : region.getValue().getChunks().entrySet()) {
 			    ExploreChunk chunk = oneChunk.getValue();
 			    if (chunk.getDbId() != -1)
 				continue;
@@ -2599,7 +2599,7 @@ public abstract class JobsDAO {
     /**
      * Save player-job information
      * @param jobInfo - the information getting saved
-     * @return 
+     * @return
      */
     public List<Integer> getLognameList(int fromtime, int untiltime) {
 	JobsConnection conn = getConnection();
@@ -2631,7 +2631,7 @@ public abstract class JobsDAO {
     /**
      * Show top list
      * @param toplist - toplist by jobs name
-     * @return 
+     * @return
      */
     public List<TopList> toplist(String jobsname) {
 	return toplist(jobsname, 0);
@@ -2640,7 +2640,7 @@ public abstract class JobsDAO {
     /**
      * Show top list
      * @param toplist - toplist by jobs name
-     * @return 
+     * @return
      */
     public List<TopList> toplist(String jobsname, int limit) {
 	List<TopList> jobs = new ArrayList<>();


### PR DESCRIPTION
Use a long to store the two ints (x is upper and z is lower) - this is guaranteed to work with any world map size out there.

It also properly handle negative values that the old implementation sometimes did not properly manage.

This might use slightly more RAM, but should provide support for actual infinite/huge map sizes

----

**Context**

Negative coordinates in both X and Z do not encode properly back and forth between `getPlace()` and `getChunkX()` + `getChunkZ()`

Steps to reproduce 

- join server
- join explorer
- walk a couple of chunks in a negative X and/or Z chunk position
- /stop the server
- join the server again
- walk the same couple of chunks
- double entries from the same user in explorerData (and XP/money are given each time)

it only bugs out if I do a `/stop `- and it's extremely reproducible on my server.

Doing `/jobs reload `and other commands do not affect it, it seems to be a storage/read back on start-up issue. 

As seen from [my debugging branch](https://github.com/jippi/Jobs/blob/jippi-debug/src/main/java/com/gamingmesh/jobs/container/ExploreRegion.java#L21-L28) the X/Z values do not always encode back and forth correctly, causing bad data (and duplicated rows) in the DB

``` 
1.18-test_1       | [19:52:17 WARN]: [Jobs] ADDING chunk value -92/13
1.18-test_1       | [19:52:17 WARN]: [Jobs] Returning would be -68/13
```

the X and Z coords matches F3 in-game, but the reversing does not 🙂
but its true for both x and z values, once the player are in negative territory, they skew


**SQLite output (same issue with MySQL)**

```
sqlite> select * from exploreData order by chunkZ,chunkX;
122|world|-68|13|1|1 
124|world|-68|13|1|1 <- duplicate of previous row
121|world|-68|14|1|1
125|world|-68|14|1|1 <- duplicate of previous row
```

**Version info**

```
[Fri, 7. Jan 2022 16:25:25 CET INFO] Jobs: 5.0.1.0 SqLite
[Fri, 7. Jan 2022 16:25:25 CET INFO] CMILib: 1.1.0.6
[Fri, 7. Jan 2022 16:25:25 CET INFO] Server: Paper(137) 1.18.1-R0.1-SNAPSHOT
[Fri, 7. Jan 2022 16:25:25 CET INFO] Economy: Essentials Economy Vault: 1.7.3-b131
```

**Plugins**

`Plugins (48): AdvancedAFK, ArmoredElytra, AuctionHouse, BungeeTabListPlus, ChestShop, ChestShopNotifier, ChestSort, CMILib, CoreProtect, DiscordSRV, DiscordSRV-Staff-Chat, dynmap, Essentials, FastChunkPregenerator, floodgate, Graves, HolographicDisplays, HoloPlots, InvSeePlusPlus, Jobs, Lands, LeaderHeadsRevamped, LevelledMobs, LuckPerms, MoreMobHeads, Multiverse-Core, Multiverse-Inventories, Multiverse-Portals, MyCommand, NetworkManager, PlaceholderAPI, PlaceholderSIGN, Plot2Dynmap, PlotSquared, ProtocolLib, ServerlistMOTD*, ShowItem, SimplePortals, spark, SurvivalInvisiframes, UnifiedMetrics, Vault, VentureChat, ViaBackwards, ViaVersion, Votifier, VotingPlugin, WorldEdit`


Signed-off-by: Christian Winther <jippignu@gmail.com>