### PR TITLE
Added option to switch bossbar creation and management to async

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
@@ -34,7 +34,19 @@ public class BossBarManager {
 	player.getUpdateBossBarFor().clear();
     }
 
-    public void ShowJobProgression(final JobsPlayer player, final JobProgression jobProg, double expGain) {
+	public void ShowJobProgression(final JobsPlayer player, final JobProgression jobProg, double expGain)
+	{
+		if(Jobs.getGCManager().isBossBarAsync())
+		{
+			Bukkit.getScheduler().runTaskAsynchronously(Jobs.getInstance(), () -> ShowJobProgressionInTask(player, jobProg, expGain));
+		}
+		else
+		{
+			ShowJobProgressionInTask(player, jobProg, expGain);
+		}
+	}
+
+	private synchronized void ShowJobProgressionInTask(final JobsPlayer player, final JobProgression jobProg, double expGain) {
 	if (Version.getCurrent().isLower(Version.v1_9_R1) || !Jobs.getGCManager().BossBarsMessageByDefault)
 	    return;
 

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -102,7 +102,7 @@ public class GeneralConfigManager {
 	BossBarEnabled = false, BossBarShowOnEachAction = false, BossBarsMessageByDefault = false, ExploreCompact, DBCleaningJobsUse, DBCleaningUsersUse,
 	DisabledWorldsUse, UseAsWhiteListWorldList, PaymentMethodsMoney, PaymentMethodsPoints, PaymentMethodsExp, MythicMobsEnabled,
 	LoggingUse, payForCombiningItems, BlastFurnacesReassign = false, SmokerReassign = false, payForStackedEntities, payForAbove = false,
-	payForEachVTradeItem, allowEnchantingBoostedItems;
+	payForEachVTradeItem, allowEnchantingBoostedItems, bossBarAsync = false;
 
     public ItemStack guiBackButton, guiNextButton;
     public CMIMaterial guiFiller;
@@ -890,6 +890,8 @@ public class GeneralConfigManager {
 	    c.addComment("BossBar.Timer", "How long in sec to show BossBar for player",
 		"If you have disabled ShowOnEachAction, then keep this number higher than payment interval for better experience");
 	    BossBarTimer = c.get("BossBar.Timer", economyBatchDelay + 1);
+		c.addComment("BossBar.Async", "If enabled, bossbar creation and management will be asynchronous.", "This avoids TPS drops when the ShowOnEachAction option is activated.");
+		bossBarAsync = c.get("BossBar.Async", false);
 	}
 
 	c.addComment("ShowActionBars", "You can enable/disable message shown for players in action bar");
@@ -1161,4 +1163,8 @@ public class GeneralConfigManager {
     public boolean isInformDuplicates() {
 	return InformDuplicates;
     }
+
+	public boolean isBossBarAsync() {
+		return bossBarAsync;
+	}
 }


### PR DESCRIPTION
Hello,

I added an option in the bossbar config to switch the creation and management of bossbars to asynchronous.
With this option the bossbars and their updates no longer have an impact on the performance of the server and on the TPS. This is useful when using the ShowOnEachAction option which can be heavy under normal circumstances without async