### PR TITLE
Resolves #1377

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PermissionManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PermissionManager.java
@@ -175,6 +175,7 @@ public class PermissionManager {
 	    if (permissions == null) {
 		permissions = getAll(player);
 	    } else {
+		permissions.clear();
 		permissions.putAll(getAll(player));
 	    }
 	    jPlayer.setPermissionsCache(permissions);


### PR DESCRIPTION
Without clearing the permissions cache, permissions that are removed will not be removed from the cache until reboot as they stay in the map.