### PR TITLE
Avoid checking limited items if none are configured

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -165,6 +165,8 @@ public final class Jobs extends JavaPlugin {
 
     public static LoadStatus status = LoadStatus.Good;
 
+	private static boolean hasLimitedItems = false;
+
     private static final int MAX_ENTRIES = 5;
     public static final LinkedHashMap<UUID, FastPayment> FASTPAYMENT = new LinkedHashMap<UUID, FastPayment>(MAX_ENTRIES + 1, .75F, false) {
 	protected boolean removeEldestEntry(Map.Entry<UUID, FastPayment> eldest) {
@@ -833,6 +835,8 @@ public final class Jobs extends JavaPlugin {
 	getGCManager().reload();
 	getLanguage().reload();
 	getConfigManager().reload();
+
+	hasLimitedItems = Jobs.getJobs().stream().anyMatch(job -> !job.getLimitedItems().isEmpty());
 
 	getDBManager().getDB().loadAllJobsWorlds();
 	getDBManager().getDB().loadAllJobsNames();
@@ -1506,4 +1510,8 @@ public final class Jobs extends JavaPlugin {
 	if (pageCount != 0)
 	    rm.show(sender);
     }
+
+	public static boolean hasLimitedItems() {
+		return hasLimitedItems;
+	}
 }

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsListener.java
@@ -382,6 +382,12 @@ public class JobsListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onLimitedItemInteract(PlayerInteractEvent event) {
+
+	if(!Jobs.hasLimitedItems())
+	{
+		return;
+	}
+
 	Player player = event.getPlayer();
 	ItemStack iih = CMIItemStack.getItemInMainHand(player);
 	if (iih.getType() == Material.AIR)


### PR DESCRIPTION
Hello,

Currently when interacting, there is a check if the item in the player's hand is a limited item from one of the jobs even when no limited item is set in any of the jobs.
So I've added a check that ignores the event if there is no limited item configured in any job.