### PR TITLE
resetexploreregion command for reseting world region data for Exploring.

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -389,7 +389,7 @@ public final class Jobs extends JavaPlugin {
 
     public static ExploreManager getExplore() {
 	if (exploreManager == null)
-	    exploreManager = new ExploreManager();
+	    exploreManager = ExploreManager.getInstane();
 	return exploreManager;
     }
 

--- a/src/main/java/com/gamingmesh/jobs/commands/list/resetexploreregion.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/resetexploreregion.java
@@ -1,0 +1,31 @@
+package com.gamingmesh.jobs.commands.list;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.commands.Cmd;
+import com.gamingmesh.jobs.config.ExploreManager;
+import org.bukkit.command.CommandSender;
+
+public class resetexploreregion implements Cmd {
+
+    private static String WORLD = "world";
+    private static String REGEX = "^[0-9a-zA-Z_-]+$";
+
+    @Override
+    public boolean perform(Jobs plugin, CommandSender sender, String[] args) {
+        if (args.length != 2 || !WORLD.equals(args[0])) {
+            Jobs.getCommandManager().sendUsage(sender, "resetexploreregion");
+            return true;
+        }
+
+        final String worldName = args[1];
+        if(!worldName.matches(REGEX)) {
+            sender.sendMessage(Jobs.getLanguage().getMessage("command.resetexploreregion.output.invalidname"));
+            return true;
+        }
+
+        ExploreManager manager = ExploreManager.getInstane();
+        manager.resetRegion(worldName);
+        sender.sendMessage(Jobs.getLanguage().getMessage("command.resetexploreregion.output.reseted", "%worldname%", worldName));
+        return true;
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/commands/list/resetexploreregion.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/resetexploreregion.java
@@ -17,6 +17,11 @@ public class resetexploreregion implements Cmd {
             return true;
         }
 
+        if (!Jobs.getGCManager().resetExploringData) {
+            sender.sendMessage(Jobs.getLanguage().getMessage("command.resetexploreregion.output.notenabled"));
+            return true;
+        }
+
         final String worldName = args[1];
         if(!worldName.matches(REGEX)) {
             sender.sendMessage(Jobs.getLanguage().getMessage("command.resetexploreregion.output.invalidname"));

--- a/src/main/java/com/gamingmesh/jobs/config/ExploreManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ExploreManager.java
@@ -19,6 +19,17 @@ import com.gamingmesh.jobs.stuff.Util;
 
 public class ExploreManager {
 
+	private static ExploreManager instance;
+	public static ExploreManager getInstane() {
+		if(null == instance) {
+			instance = new ExploreManager();
+		}
+		return instance;
+	}
+
+	private ExploreManager() {
+	}
+
     private final Map<String, Map<String, ExploreRegion>> worlds = new HashMap<>();
     private boolean exploreEnabled = false;
     private int playerAmount = 1;
@@ -139,4 +150,18 @@ public class ExploreManager {
 	}
     }
 
+	public void resetRegion(String worldname) {
+		Jobs.consoleMsg("&eReseting explorer data. World: " + worldname);
+
+		Map<String, Map<String, ExploreRegion>> worlds = getWorlds();
+		worlds.put(worldname, new HashMap<String, ExploreRegion>());
+
+		boolean r = Jobs.getJobsDAO().deleteExploredWorld(worldname);
+		if(!r) {
+			Jobs.consoleMsg("&eFailed in DAO.");
+			return;
+		}
+
+		Jobs.consoleMsg("&eCompleted to reset explorer data.");
+	}
 }

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -89,7 +89,7 @@ public class GeneralConfigManager {
     public boolean ignoreOreGenerators, useBlockProtection, enableSchedule, PayForRenaming, PayForEnchantingOnAnvil, PayForEachCraft, SignsEnabled,
 	SignsColorizeJobName, ShowToplistInScoreboard, useGlobalTimer, useSilkTouchProtection, UseCustomNames,
 	PreventSlimeSplit, PreventMagmaCubeSplit, PreventHopperFillUps, PreventBrewingStandFillUps,
-	BrowseUseNewLook, payExploringWhenGliding = false, disablePaymentIfMaxLevelReached, disablePaymentIfRiding,
+	BrowseUseNewLook, payExploringWhenGliding = false, resetExploringData = false, disablePaymentIfMaxLevelReached, disablePaymentIfRiding,
 	boostedItemsInOffHand = false, boostedItemsInMainHand, boostedArmorItems/*, preventCropResizePayment*/, payItemDurabilityLoss,
 	applyToNegativeIncome, useMinimumOveralPayment, useMinimumOveralPoints, useMinimumOveralExp, useBreederFinder,
 	CancelCowMilking, fixAtMaxLevel, TitleChangeChat, TitleChangeActionBar, LevelChangeChat,
@@ -455,6 +455,9 @@ public class GeneralConfigManager {
 	    c.addComment("enable-pay-for-exploring-when-gliding", "Option to allow payment to be made for exploring when player gliding.");
 	    payExploringWhenGliding = c.get("enable-pay-for-exploring-when-gliding", false);
 	}
+
+	c.addComment("enable-reset-exploring-data", "Option to allow reset exploring data.");
+	resetExploringData = c.get("enable-reset-exploring-data", false);
 
 	c.addComment("disablePaymentIfRiding", "Disables the payment when the player riding on an entity.");
 	disablePaymentIfRiding = c.get("disablePaymentIfRiding", false);

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -209,11 +209,17 @@ public class LanguageManager {
 	    c.get("command.limit.output.reachedpointslimit2", "&eYou can check your limit with &2/jobs limit &ecommand");
 	    c.get("command.limit.output.notenabled", "&eMoney limit is not enabled");
 
-	    c.get("command.resetlimit.help.info", "Resets a player's payment limits");
+		c.get("command.resetexploreregion.help.info", "Resets world data of Explorering");
+		c.get("command.resetexploreregion.help.args", "world [worldname]");
+		Jobs.getGCManager().getCommandArgs().put("resetlimit", Arrays.asList("world", "[worldname]"));
+		c.get("command.resetexploreregion.output.invalidname", "&eInvalid world name");
+		c.get("command.resetexploreregion.output.reseted", "&eWorld data has been reset for: &2%worldname%");
+
+		c.get("command.resetlimit.help.info", "Resets a player's payment limits");
 	    c.get("command.resetlimit.help.args", "[playername]");
 	    Jobs.getGCManager().getCommandArgs().put("resetlimit", Arrays.asList("[playername]"));
-	    c.get("command.resetlimit.output.reseted", "&ePayment limits have been reset for: &2%playername%");
-	    
+		c.get("command.resetlimit.output.reseted", "&ePayment limits have been reset for: &2%playername%");
+
 	    c.get("command.resetquesttotal.help.info", "Resets a player's done quest counter");
 	    c.get("command.resetquesttotal.help.args", "[playername]/all");
 	    Jobs.getGCManager().getCommandArgs().put("resetquesttotal", Arrays.asList("[playername]%%all"));

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -209,11 +209,12 @@ public class LanguageManager {
 	    c.get("command.limit.output.reachedpointslimit2", "&eYou can check your limit with &2/jobs limit &ecommand");
 	    c.get("command.limit.output.notenabled", "&eMoney limit is not enabled");
 
-		c.get("command.resetexploreregion.help.info", "Resets world data of Explorering");
+		c.get("command.resetexploreregion.help.info", "Resets region data of Explorering");
 		c.get("command.resetexploreregion.help.args", "world [worldname]");
 		Jobs.getGCManager().getCommandArgs().put("resetlimit", Arrays.asList("world", "[worldname]"));
+		c.get("command.resetexploreregion.output.notenabled", "&eNot enabled.");
 		c.get("command.resetexploreregion.output.invalidname", "&eInvalid world name");
-		c.get("command.resetexploreregion.output.reseted", "&eWorld data has been reset for: &2%worldname%");
+		c.get("command.resetexploreregion.output.reseted", "&eExploring region data has been reset for: &2%worldname%");
 
 		c.get("command.resetlimit.help.info", "Resets a player's payment limits");
 	    c.get("command.resetlimit.help.args", "[playername]");

--- a/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
+++ b/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
@@ -2613,7 +2613,38 @@ public abstract class JobsDAO {
 
     }
 
-    /**
+	/**
+	 * Delete player-explore information
+	 * @param worldName - the world getting removed
+	 */
+	public boolean deleteExploredWorld(String worldName) {
+		if (!Jobs.getExplore().isExploreEnabled())
+			return false;
+
+		JobsConnection conn = getConnection();
+		if (conn == null)
+			return false;
+
+		JobsWorld target = Util.getJobsWorld(worldName);
+		if (null == target) {
+			return false;
+		}
+
+		PreparedStatement prest = null;
+		try {
+			prest = conn.prepareStatement("DELETE FROM `" + DBTables.ExploreDataTable.getTableName() + "` WHERE `" + ExploreDataTableFields.worldid.getCollumn() + "` = ?;");
+			prest.setInt(1, target.getId());
+			prest.execute();
+		} catch (Throwable e) {
+			e.printStackTrace();
+			return false;
+		} finally {
+			close(prest);
+		}
+		return true;
+	}
+
+	/**
      * Save player-job information
      * @param jobInfo - the information getting saved
      * @return

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -156,6 +156,7 @@ command:
       info: '指定したワールドの探索情報をリセットします'
       args: 'world [worldname]'
     output:
+      notenabled: '機能が無効化されています'
       invalidname: 'ワールド名が不正です'
       reseted: '&2%worldname% &eの探索情報をリセットしました'
   resetlimit:

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -151,6 +151,13 @@ command:
       reachedpointslimit: '&4ポイント獲得上限に達しました'
       reachedpointslimit2: '&2/jobs limit &eコマンドで上限を確認できます'
       notenabled: '&e上限は有効化されていません'
+  resetexploreregion:
+    help:
+      info: '指定したワールドの探索情報をリセットします'
+      args: 'world [worldname]'
+    output:
+      invalidname: 'ワールド名が不正です'
+      reseted: '&2%worldname% &eの探索情報をリセットしました'
   resetlimit:
     help:
       info: '[player]の上限をリセットします'
@@ -416,14 +423,14 @@ command:
       info: '[職業名]を離職します'
       args: '[oldplayerjob]'
     success: '%jobname% を離職しました'
-    confirmationNeed: '&cAre you sure you want to leave from&e [jobname]&c job? Type the command again within&6 [time] seconds &cto confirm!'
+    confirmationNeed: '&c本当に &e[jobname] &cから離職しますか？ 離職する場合は &6[time]&c 秒以内に再度コマンドを実行してください'
   leaveall:
     help:
       info: 就いている全ての職業を離職します
     error:
       nojobs: 離職できる職業はありません
     success: 就いている全ての職業を離職しました
-    confirmationNeed: '&cAre you sure you want to leave from all jobs? Type the command again within&6 [time] seconds &cto confirm!'
+    confirmationNeed: '&c本当に &e全てのジョブ&c から離職しますか？ 離職する場合は &6[time]&c 秒以内に再度コマンドを実行してください'
   explored:
     help:
       info: このチャンクに来たことのある人を確認できます


### PR DESCRIPTION
Changes:
- resetexploreregion command is added.
- resetexploreregion function is disabled by default until enabled in generalConfig.yml.

My Minecraft server has a resource world so that players can get blocks and items as they want and it is re-created periodically. Explorer job is wonderful but it doesn't work on the resource world since region data is kept even after reseting world. This command is to help players enjoying Exploring new word after reset.