### PR TITLE
Removed redundant McMMO Listener

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/hooks/McMMO/McMMO1_X_listener.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/McMMO/McMMO1_X_listener.java
@@ -22,34 +22,6 @@ import com.gmail.nossr50.events.skills.repair.McMMOPlayerRepairCheckEvent;
 public class McMMO1_X_listener implements Listener {
 
     @EventHandler
-    public void onFishingTreasure(McMMOPlayerFishingTreasureEvent event) {
-	Player player = event.getPlayer();
-	//disabling plugin in world
-	if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld()))
-	    return;
-
-	// check if in creative
-	if (!JobsPaymentListener.payIfCreative(player))
-	    return;
-
-	if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getLocation().getWorld().getName()))
-	    return;
-
-	// check if player is riding
-	if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle())
-	    return;
-
-	if (!JobsPaymentListener.payForItemDurabilityLoss(player) || event.getTreasure() == null)
-	    return;
-
-	JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(player);
-	if (jPlayer == null)
-	    return;
-
-	Jobs.action(jPlayer, new ItemActionInfo(event.getTreasure(), ActionType.FISH));
-    }
-
-    @EventHandler
     public void OnItemrepair(McMMOPlayerRepairCheckEvent event) {
 	Player player = event.getPlayer();
 	//disabling plugin in world

--- a/src/main/java/com/gamingmesh/jobs/hooks/McMMO/McMMO2_X_listener.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/McMMO/McMMO2_X_listener.java
@@ -23,37 +23,6 @@ import com.gmail.nossr50.events.skills.repair.McMMOPlayerRepairCheckEvent;
 public class McMMO2_X_listener implements Listener {
 
     @EventHandler
-    public void onFishingTreasure(McMMOPlayerFishingTreasureEvent event) {
-	Player player = event.getPlayer();
-	//disabling plugin in world
-	if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld()))
-	    return;
-
-	// check if in creative
-	if (!JobsPaymentListener.payIfCreative(player))
-	    return;
-
-	if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getLocation().getWorld().getName()))
-	    return;
-
-	// check if player is riding
-	if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle())
-	    return;
-
-	if (!JobsPaymentListener.payForItemDurabilityLoss(player))
-	    return;
-
-	if (event.getTreasure() == null)
-	    return;
-
-	JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(player);
-	if (jPlayer == null)
-	    return;
-
-	Jobs.action(jPlayer, new ItemActionInfo(event.getTreasure(), ActionType.FISH));
-    }
-
-    @EventHandler
     public void OnItemrepair(McMMOPlayerRepairCheckEvent event) {
 	Player player = event.getPlayer();
 	// disabling plugin in world


### PR DESCRIPTION
Possible fix to issue `Fishing mcMMO Treasure Pays 2X The Set Value #1438`

When you fish an mcMMO Treasure item, it pays twice as much as the value you have configured it to pay. After looking at the code, It seemed that both mcMMO and the fishing event was being triggered. One possible solution is to remove the mcMMO listener as the loot was already registering with the fishing event.