### PR TITLE
Add config option for preventing enchantments on shop items

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -102,7 +102,7 @@ public class GeneralConfigManager {
 	BossBarEnabled = false, BossBarShowOnEachAction = false, BossBarsMessageByDefault = false, ExploreCompact, DBCleaningJobsUse, DBCleaningUsersUse,
 	DisabledWorldsUse, UseAsWhiteListWorldList, PaymentMethodsMoney, PaymentMethodsPoints, PaymentMethodsExp, MythicMobsEnabled,
 	LoggingUse, payForCombiningItems, BlastFurnacesReassign = false, SmokerReassign = false, payForStackedEntities, payForAbove = false,
-	payForEachVTradeItem, allowEnchantingBoostedItems, bossBarAsync = false;
+	payForEachVTradeItem, allowEnchantingBoostedItems, bossBarAsync = false, preventShopItemEnchanting;
 
     public ItemStack guiBackButton, guiNextButton;
     public CMIMaterial guiFiller;
@@ -439,6 +439,9 @@ public class GeneralConfigManager {
 
 	c.addComment("hide-jobsinfo-without-permission", "Hide jobs info from player if they lack the permission to join the job");
 	hideJobsInfoWithoutPermission = c.get("hide-jobsinfo-without-permission", false);
+
+	c.addComment("prevent-shop-item-enchanting", "Prevent players to enchant items from the shop in the anvil with enchanted books");
+	preventShopItemEnchanting = c.get("prevent-shop-item-enchanting", true);
 
 	c.addComment("enable-pay-near-spawner",
 	    "Option to allow payment to be made when killing mobs from a spawner.",

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -26,6 +26,7 @@ import java.util.Map.Entry;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import com.gamingmesh.jobs.config.GeneralConfigManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -1082,6 +1083,9 @@ public final class JobsPaymentListener implements Listener {
 
     @EventHandler(priority = EventPriority.NORMAL)
     public void PrepareAnvilEvent(final PrepareAnvilEvent event) {
+	if (!Jobs.getGCManager().preventShopItemEnchanting)
+		return;
+
 	if (!Jobs.getPlayerManager().containsItemBoostByNBT(event.getInventory().getContents()[0]))
 	    return;
 


### PR DESCRIPTION
Currently, the plugin prevents enchantments on all items from the shop.
This might not be desired on all servers, since some servers sell utility items like pickaxes on the shop.
That's why I've added a config option to disable this behaviour.