### PR TITLE
Fix output of boolean placeholders, revert 3d2f4d7

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Placeholders/Placeholder.java
+++ b/src/main/java/com/gamingmesh/jobs/Placeholders/Placeholder.java
@@ -667,6 +667,6 @@ public class Placeholder {
     }
 
     private static String convert(boolean state) {
-	return state ? LC.info_variables_True.getLocale() : LC.info_variables_False.getLocale();
+	return state ? "true" : "false";
     }
 }


### PR DESCRIPTION
After integrating CMILib into the Placeholders, the integration with other plugins has broken because PlaceholderAPI (PAPI) is not able to parse the output as boolean.

This commit reverts part of commit 3d2f4d710a8512581d1cf80ae8cef240fbf463fc

What does this commit?
- Changes the output of Placeholder::convert() from colorized translations to raw strings "true" and "false"