### PR TITLE
Jobs fishing listener MCMMO fix

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -543,7 +543,7 @@ public final class JobsPaymentListener implements Listener {
 
                 // check is the fishing being exploited. If yes, prevent payment.
                 if (mcMMOPlayer != null && ExperienceConfig.getInstance().isFishingExploitingPrevented()
-                    && mcMMOPlayer.getFishingManager().isExploitingFishing(event.getHook().getLocation().toVector())) {
+                    && mcMMOPlayer.getFishingManager().isFishingTooOften()) {
                     return;
                 }
             }


### PR DESCRIPTION
When fishing, and you get warned by `MCMMO` you don't get paid.

This is because `isExploitingFishing` returns true when a player is warned.

It should be `isFishingTooOfter` as it returns true when they should not catch a fish.

This is seen in the `MCMMO` plugin at `PlayerListener.java`
```java
//Spam Fishing
if(event.getState() == PlayerFishEvent.State.CAUGHT_FISH && fishingManager.isFishingTooOften()) {
   event.setExpToDrop(0);

  if(caught instanceof Item caughtItem) {
    caughtItem.remove();
  }

  return;
}
```

I think it makes more sense that players should still get paid for catching the fish. At the moment players do not get paid for catching the fish.