### PR TITLE
Reverted fishing exploiting

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -543,7 +543,7 @@ public final class JobsPaymentListener implements Listener {
 
                 // check is the fishing being exploited. If yes, prevent payment.
                 if (mcMMOPlayer != null && ExperienceConfig.getInstance().isFishingExploitingPrevented()
-                    && mcMMOPlayer.getFishingManager().isFishingTooOften()) {
+                    && mcMMOPlayer.getFishingManager().isExploitingFishing(event.getHook().getLocation().toVector())) {
                     return;
                 }
             }


### PR DESCRIPTION
**Reverting this:**
https://github.com/Zrips/Jobs/commit/7a63a615b4b7acbc89df7a99c788fcbbc9048bcc

Sorry for the confusion, I've messed up. It looks like `it was correct in the first place` and now its broken D:
After suggesting this change you currently `get paid even if there are no fish`.

I'm not sure why as stated in the last commit, you don't get paid when warned. I'll look more into it at another time, but could this be changed back to fix the `MCMMO fishing hook`?