### PR TITLE
Taking highest boost into consideration

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
@@ -387,15 +387,15 @@ public class JobsPlayer {
         Double boost = v1;
 
         v1 = Jobs.getPermissionManager().getMaxPermission(this, "jobs.boost." + jobName + ".all", false, false);
-        if (v1 != 0d && (v1 > boost || v1 < boost))
+        if (v1 != 0d && (v1 > boost /*|| v1 < boost*/))
             boost = v1;
 
         v1 = Jobs.getPermissionManager().getMaxPermission(this, "jobs.boost.all.all", false, false);
-        if (v1 != 0d && (v1 > boost || v1 < boost))
+        if (v1 != 0d && (v1 > boost /*|| v1 < boost*/))
             boost = v1;
 
         v1 = Jobs.getPermissionManager().getMaxPermission(this, "jobs.boost.all." + type.getName(), false, false);
-        if (v1 != 0d && (v1 > boost || v1 < boost))
+        if (v1 != 0d && (v1 > boost /*|| v1 < boost*/))
             boost = v1;
 
         return boost;


### PR DESCRIPTION
Hello, I've been asked to slightly modify the boost system and make this pull request.

**Modified behaviour**:
Now taking the highest boost into consideration for each CurrencyType, even if it's set in a lower permission, instead of having higher permissions such as "jobs.boost.all.<type>" permission overwriting a lower value.

**Example:**
For instance, the previous behaviour would be:
1. Gaining $10 + 10 points + 10xp
2. Giving permission `jobs.boost.all.exp.0.2` (for a 20% boost on xp)
3. Now gaining $10 + 10 points + 12xp (all good)
4. Giving permission `jobs.boost.all.all.1` (for a 100% boost on everything)
5. Now gaining $20 + 20 points + 12xp (the 100% boost did not apply on the xp, only the lowest one of 20%, since it's checked first in the current code)

With this pull request, step 5 would now be now gaining $20 + 20 points + 20xp, taking the highest boost for each currency.