### PR TITLE
Allow payment for tilling dirt

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -488,7 +488,8 @@ public final class JobsPaymentListener implements Listener {
             return;
 
         // A tool should not trigger a BlockPlaceEvent (fixes stripping logs bug #940)
-        if (CMIMaterial.get(event.getItemInHand().getType()).isTool())
+        // Allow this to trigger with a hoe so players can get paid for farmland.
+        if (CMIMaterial.get(event.getItemInHand().getType()).isTool() && !event.getItemInHand().getType().toString().endsWith("_HOE"))
             return;
 
         Block block = event.getBlock();


### PR DESCRIPTION
Adds a check to see if a player's hand item is a hoe and allows the code to continue.