### PR TITLE
Improve Berry Checks

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1750,12 +1750,15 @@ public final class JobsPaymentListener implements Listener {
                     if (level.getLevel() == level.getMaximumLevel()) {
                         Jobs.action(jPlayer, new BlockCollectInfo(CMIMaterial.BONE_MEAL, ActionType.COLLECT), block);
                     }
-                } else if ((cmat == CMIMaterial.SWEET_BERRY_BUSH || cmat == CMIMaterial.CAVE_VINES_PLANT || cmat == CMIMaterial.CAVE_VINES) && hand != CMIMaterial.BONE_MEAL.getMaterial()) {
+                } else if ((cmat == CMIMaterial.SWEET_BERRY_BUSH || cmat == CMIMaterial.CAVE_VINES_PLANT || cmat == CMIMaterial.CAVE_VINES)) {
 
                     if (cmat == CMIMaterial.SWEET_BERRY_BUSH) {
                         Ageable age = (Ageable) block.getBlockData();
-                        if (age.getAge() >= 2)
+                        if (age.getAge() == 2 && hand != CMIMaterial.BONE_MEAL.getMaterial()) {
                             Jobs.action(jPlayer, new BlockCollectInfo(CMIMaterial.SWEET_BERRIES, ActionType.COLLECT, age.getAge()), block);
+                        } else if (age.getAge() == 3) {
+                            Jobs.action(jPlayer, new BlockCollectInfo(CMIMaterial.SWEET_BERRIES, ActionType.COLLECT, age.getAge()), block);
+                        }
                     } else {
                         org.bukkit.block.data.type.CaveVinesPlant caveVines = (org.bukkit.block.data.type.CaveVinesPlant) block.getBlockData();
                         if (caveVines.isBerries()) {


### PR DESCRIPTION
Allow payment when holding bonemeal by checking the plant's age.

This will allow players to farm without having to switch to another item for payment.