### PR TITLE
Check if the player's food level is at its maximum

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1642,7 +1642,7 @@ public final class JobsPaymentListener implements Listener {
 
         Player player = (Player) human;
 
-        if (!player.isOnline() || event.getFoodLevel() <= player.getFoodLevel())
+        if (!player.isOnline() || event.getFoodLevel() <= player.getFoodLevel() || player.getFoodLevel() == 20)
             return;
 
         // check if in creative


### PR DESCRIPTION
A few foods can be eaten with the maximum food level. This prevents payment in that situation.