### PR TITLE
Fix auto join when max-jobs is 0

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -1212,13 +1212,9 @@ public class PlayerManager {
                     return;
 
                 int playerMaxJobs = getMaxJobs(jPlayer);
-                int playerCurrentJobs = jPlayer.progression.size();
-
-                if (playerMaxJobs <= 0 || playerCurrentJobs >= playerMaxJobs)
-                    return;
 
                 for (Job one : Jobs.getJobs()) {
-                    if (jPlayer.progression.size() >= playerMaxJobs)
+                    if (playerMaxJobs > 0 && jPlayer.progression.size() >= playerMaxJobs)
                         return;
 
                     if (one.getMaxSlots() != null && Jobs.getUsedSlots(one) >= one.getMaxSlots())


### PR DESCRIPTION
Setting `max-jobs` to 0 in `generalConfig.yml` is supposed to remove the limit for jobs per player, but this was no longer working correctly with auto join anymore. In the past, the auto join logic used to check a player's of  jobs against the maximum only if it was greater than 0. Commit https://github.com/Zrips/Jobs/commit/bf064408114bcc6467c53ccd280fa563f1fc4d67 rewrote some of that logic, and mistakenly resulted auto join getting cancelled if the maximum limit was disabled. It was probably meant to only check the player's jobs if a limit was set, but instead skipped the auto join logic entirely when no limit was set. This resulted in a breaking change, requiring users to set a job limit for auto join to work.

This PR fixes that, making the auto join check the number of player jobs against the maximum limit only if it is greater than 0.
It also removes a redundant comparison of `jPlayer.progression.size()` with `playerMaxJobs`, as this check already happens in the for loop.