### PR TITLE
Fixed order of operations for jobs limit display.

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/limit.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/limit.java
@@ -65,7 +65,7 @@ public class limit implements Cmd {
 
                 Language.sendMessage(sender, "command.limit.output." + typeName + "time", "%time%", CMITimeManager.to24hourShort(limit.getLeftTime(type)));
                 Language.sendMessage(sender, "command.limit.output." + typeName + "Limit",
-                    "%current%", (int) (limit.getAmount(type) * 100) / 100D,
+                    "%current%", (int) ((limit.getAmount(type) * 100) / 100D),
                     "%total%", JPlayer.getLimit(type));
             }
         }


### PR DESCRIPTION
Fix for [this issue](https://github.com/Zrips/Jobs/issues/1623) to do with the jobs limit display.
Added parentheses to fix order of operations issue.