### PR TITLE
Add possibility to be hidden from jobs tops

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/HookEconomyTask.java
+++ b/src/main/java/com/gamingmesh/jobs/HookEconomyTask.java
@@ -18,63 +18,17 @@
 
 package com.gamingmesh.jobs;
 
-import org.bukkit.plugin.RegisteredServiceProvider;
-
-import com.gamingmesh.jobs.economy.BlackholeEconomy;
 import com.gamingmesh.jobs.economy.VaultEconomy;
-
-import net.Zrips.CMILib.Messages.CMIMessages;
 import net.milkbowl.vault.economy.Economy;
 
-public class HookEconomyTask implements Runnable {
+public class HookEconomyTask extends HookVault<Economy> {
 
-    private Jobs plugin;
-
-    public HookEconomyTask(Jobs plugin) {
-        this.plugin = plugin;
-    }
-
-    enum hookResult {
-        novault, noeconomy, pass;
-
+    public HookEconomyTask(Class<Economy> providerClass) {
+        super(providerClass);
     }
 
     @Override
-    public void run() {
-
-        hookResult result = setVault();
-
-        if (result.equals(hookResult.pass)) {
-            return;
-        }
-
-        // no Economy found
-        Jobs.setEconomy(new BlackholeEconomy());
-        Jobs.getPluginLogger().severe("==================== " + plugin.getDescription().getName() + " ====================");
-        if (result.equals(hookResult.novault)) {
-            Jobs.getPluginLogger().severe("Vault is required by this plugin for economy support!");
-            Jobs.getPluginLogger().severe("Please install them first!");
-            Jobs.getPluginLogger().severe("You can find the latest versions here:");
-            Jobs.getPluginLogger().severe("https://www.spigotmc.org/resources/34315/");
-        } else {
-            Jobs.getPluginLogger().severe("Vault detected but economy plugin still missing!");
-            Jobs.getPluginLogger().severe("Please install Vault supporting economy plugin!");
-        }
-        Jobs.getPluginLogger().severe("==============================================");
-    }
-
-    private hookResult setVault() {
-        if (!plugin.getServer().getPluginManager().isPluginEnabled("Vault"))
-            return hookResult.novault;
-
-        RegisteredServiceProvider<Economy> provider = plugin.getServer().getServicesManager().getRegistration(Economy.class);
-        if (provider == null) {
-            return hookResult.noeconomy;
-        }
-
+    void runIfProviderIsFound() {
         Jobs.setEconomy(new VaultEconomy(provider.getProvider()));
-        CMIMessages.consoleMessage("&e[" + plugin.getDescription().getName() + "] Successfully linked with Vault. (" + provider.getProvider().getName() + ")");
-        return hookResult.pass;
     }
-
 }

--- a/src/main/java/com/gamingmesh/jobs/HookPermissionTask.java
+++ b/src/main/java/com/gamingmesh/jobs/HookPermissionTask.java
@@ -1,0 +1,15 @@
+package com.gamingmesh.jobs;
+
+import net.milkbowl.vault.permission.Permission;
+
+public class HookPermissionTask extends HookVault<Permission> {
+
+    public HookPermissionTask(Class<Permission> providerClass) {
+        super(providerClass);
+    }
+
+    @Override
+    void runIfProviderIsFound() {
+        Jobs.setVaultPermission(this.provider.getProvider());
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/HookVault.java
+++ b/src/main/java/com/gamingmesh/jobs/HookVault.java
@@ -1,0 +1,60 @@
+package com.gamingmesh.jobs;
+
+import net.Zrips.CMILib.Messages.CMIMessages;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+public abstract class HookVault<T> {
+    private static Boolean vaultEnable = null;
+    protected Class<T> providerClass;
+    protected RegisteredServiceProvider<T> provider;
+
+    protected HookVault(Class<T> providerClass) {
+        this.providerClass = providerClass;
+        if (!isVaultEnable())return;
+        this.provider = Jobs.getInstance().getServer().getServicesManager().getRegistration(this.providerClass);
+        if (this.provider != null) {
+            logProviderConnected();
+            runIfProviderIsFound();
+        } else {
+            logProviderNotFound();
+        }
+    }
+
+    public static boolean isVaultEnable() {
+        if (vaultEnable == null) {
+            setIsVaultEnable();
+            if (!vaultEnable)
+                logIfVaultIsNotEnable();
+        }
+        return vaultEnable;
+    }
+
+    private static void setIsVaultEnable() {
+        vaultEnable = Jobs.getInstance().getServer().getPluginManager().isPluginEnabled("Vault");
+    }
+
+    public static void logIfVaultIsNotEnable() {
+        if (vaultEnable)return;
+        Jobs.getPluginLogger().severe("==================== " + Jobs.getInstance().getName() + " ====================");
+        Jobs.getPluginLogger().severe("Vault is required by this plugin for economy support!");
+        Jobs.getPluginLogger().severe("Please install them first!");
+        Jobs.getPluginLogger().severe("You can find the latest versions here:");
+        Jobs.getPluginLogger().severe("https://www.spigotmc.org/resources/34315/");
+        Jobs.getPluginLogger().severe("==============================================");
+    }
+
+    public void logProviderNotFound() {
+        if (this.provider == null && isVaultEnable()) {
+            Jobs.getPluginLogger().severe("==================== " + Jobs.getInstance().getDescription().getName() + " ====================");
+            Jobs.getPluginLogger().severe("Vault detected but " + this.providerClass.getSimpleName() + " plugin still missing!");
+            Jobs.getPluginLogger().severe("Please install Vault supporting " + this.providerClass.getSimpleName() + " plugin!");
+            Jobs.getPluginLogger().severe("==============================================");
+        }
+    }
+
+    protected void logProviderConnected() {
+        CMIMessages.consoleMessage("&e[" + Jobs.getInstance().getName() + "] Successfully linked with Vault. (" + provider.getPlugin().getName() + ")");
+    }
+
+    abstract void runIfProviderIsFound();
+}

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -720,11 +720,14 @@ public final class Jobs extends JavaPlugin {
                 complement = new Complement1();
             }
 
-            // register economy
-            CMIScheduler.get().runTask(() -> new HookEconomyTask(net.milkbowl.vault.economy.Economy.class));
+            if (HookVault.isVaultEnable()) {
+                // register economy
+                CMIScheduler.get().runTask(() -> new HookEconomyTask(net.milkbowl.vault.economy.Economy.class));
 
-            // register permission from vault
-            CMIScheduler.get().runTask(() -> new HookPermissionTask(Permission.class));
+                // register permission from vault
+                CMIScheduler.get().runTask(() -> new HookPermissionTask(Permission.class));
+            }
+
 
             dao.loadBlockProtection();
             getExploreManager().load();

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -18,28 +18,6 @@
 
 package com.gamingmesh.jobs;
 
-import java.io.File;
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
-import java.util.WeakHashMap;
-import java.util.logging.Logger;
-
-import org.bukkit.Bukkit;
-import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.HandlerList;
-import org.bukkit.plugin.java.JavaPlugin;
-
 import com.gamingmesh.jobs.Gui.GuiManager;
 import com.gamingmesh.jobs.Placeholders.Placeholder;
 import com.gamingmesh.jobs.Placeholders.PlaceholderAPIHook;
@@ -47,40 +25,8 @@ import com.gamingmesh.jobs.Signs.SignUtil;
 import com.gamingmesh.jobs.api.JobsExpGainEvent;
 import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
 import com.gamingmesh.jobs.commands.JobsCommands;
-import com.gamingmesh.jobs.config.BlockProtectionManager;
-import com.gamingmesh.jobs.config.BossBarManager;
-import com.gamingmesh.jobs.config.ConfigManager;
-import com.gamingmesh.jobs.config.ExploreManager;
-import com.gamingmesh.jobs.config.GeneralConfigManager;
-import com.gamingmesh.jobs.config.LanguageManager;
-import com.gamingmesh.jobs.config.NameTranslatorManager;
-import com.gamingmesh.jobs.config.RestrictedAreaManager;
-import com.gamingmesh.jobs.config.RestrictedBlockManager;
-import com.gamingmesh.jobs.config.ScheduleManager;
-import com.gamingmesh.jobs.config.ShopManager;
-import com.gamingmesh.jobs.config.TitleManager;
-import com.gamingmesh.jobs.config.YmlMaker;
-import com.gamingmesh.jobs.container.ActionInfo;
-import com.gamingmesh.jobs.container.ActionType;
-import com.gamingmesh.jobs.container.ArchivedJobs;
-import com.gamingmesh.jobs.container.BlockProtection;
-import com.gamingmesh.jobs.container.Boost;
-import com.gamingmesh.jobs.container.Convert;
-import com.gamingmesh.jobs.container.CurrencyLimit;
-import com.gamingmesh.jobs.container.CurrencyType;
-import com.gamingmesh.jobs.container.DBAction;
-import com.gamingmesh.jobs.container.FastPayment;
-import com.gamingmesh.jobs.container.Job;
-import com.gamingmesh.jobs.container.JobInfo;
-import com.gamingmesh.jobs.container.JobProgression;
-import com.gamingmesh.jobs.container.JobsPlayer;
-import com.gamingmesh.jobs.container.JobsWorld;
-import com.gamingmesh.jobs.container.LoadStatus;
-import com.gamingmesh.jobs.container.Log;
-import com.gamingmesh.jobs.container.PlayerInfo;
-import com.gamingmesh.jobs.container.PlayerPoints;
-import com.gamingmesh.jobs.container.Quest;
-import com.gamingmesh.jobs.container.QuestProgression;
+import com.gamingmesh.jobs.config.*;
+import com.gamingmesh.jobs.container.*;
 import com.gamingmesh.jobs.container.blockOwnerShip.BlockOwnerShip;
 import com.gamingmesh.jobs.container.blockOwnerShip.BlockTypes;
 import com.gamingmesh.jobs.dao.JobsClassLoader;
@@ -93,32 +39,35 @@ import com.gamingmesh.jobs.economy.Economy;
 import com.gamingmesh.jobs.economy.PaymentData;
 import com.gamingmesh.jobs.hooks.HookManager;
 import com.gamingmesh.jobs.i18n.Language;
-import com.gamingmesh.jobs.listeners.JobsListener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_14Listener;
-import com.gamingmesh.jobs.listeners.JobsPaymentListener;
-import com.gamingmesh.jobs.listeners.PistonProtectionListener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_16Listener;
-import com.gamingmesh.jobs.listeners.PlayerSignEdit1_20Listeners;
+import com.gamingmesh.jobs.listeners.*;
 import com.gamingmesh.jobs.selection.SelectionManager;
-import com.gamingmesh.jobs.stuff.Loging;
-import com.gamingmesh.jobs.stuff.TabComplete;
-import com.gamingmesh.jobs.stuff.ToggleBarHandling;
-import com.gamingmesh.jobs.stuff.Util;
-import com.gamingmesh.jobs.stuff.VersionChecker;
+import com.gamingmesh.jobs.stuff.*;
 import com.gamingmesh.jobs.stuff.complement.Complement;
 import com.gamingmesh.jobs.stuff.complement.Complement1;
 import com.gamingmesh.jobs.stuff.complement.Complement2;
 import com.gamingmesh.jobs.stuff.complement.JobsChatEvent;
 import com.gamingmesh.jobs.tasks.BufferedPaymentThread;
 import com.gamingmesh.jobs.tasks.DatabaseSaveThread;
-
 import net.Zrips.CMILib.ActionBar.CMIActionBar;
 import net.Zrips.CMILib.Items.CMIMaterial;
 import net.Zrips.CMILib.Locale.LC;
 import net.Zrips.CMILib.Messages.CMIMessages;
 import net.Zrips.CMILib.RawMessages.RawMessage;
-import net.Zrips.CMILib.Version.Version;
 import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
+import net.Zrips.CMILib.Version.Version;
+import net.milkbowl.vault.permission.Permission;
+import org.bukkit.Bukkit;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.plugin.java.JavaPlugin;
+
+import java.io.File;
+import java.sql.SQLException;
+import java.util.*;
+import java.util.logging.Logger;
 
 public final class Jobs extends JavaPlugin {
 
@@ -142,6 +91,8 @@ public final class Jobs extends JavaPlugin {
     private static GeneralConfigManager gConfigManager;
 
     private static BufferedEconomy economy;
+
+    private static Permission vaultPermission;
     private static PermissionHandler permissionHandler;
     private static PermissionManager permissionManager;
 
@@ -691,12 +642,20 @@ public final class Jobs extends JavaPlugin {
         economy = new BufferedEconomy(getInstance(), eco);
     }
 
+    public static void setVaultPermission(Permission permission) {
+        vaultPermission = permission;
+    }
+
     /**
      * Gets the economy handler
      * @return the economy handler
      */
     public static BufferedEconomy getEconomy() {
         return economy;
+    }
+
+    public static Permission getVaultPermission() {
+        return vaultPermission;
     }
 
     /**
@@ -762,7 +721,10 @@ public final class Jobs extends JavaPlugin {
             }
 
             // register economy
-            CMIScheduler.get().runTask(new HookEconomyTask(this));
+            CMIScheduler.get().runTask(() -> new HookEconomyTask(net.milkbowl.vault.economy.Economy.class));
+
+            // register permission from vault
+            CMIScheduler.get().runTask(() -> new HookPermissionTask(Permission.class));
 
             dao.loadBlockProtection();
             getExploreManager().load();

--- a/src/main/java/com/gamingmesh/jobs/commands/list/top.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/top.java
@@ -1,22 +1,23 @@
 package com.gamingmesh.jobs.commands.list;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-import org.bukkit.scoreboard.DisplaySlot;
-
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.commands.Cmd;
 import com.gamingmesh.jobs.container.Job;
 import com.gamingmesh.jobs.container.TopList;
 import com.gamingmesh.jobs.i18n.Language;
-
 import net.Zrips.CMILib.Container.PageInfo;
 import net.Zrips.CMILib.Locale.LC;
 import net.Zrips.CMILib.Messages.CMIMessages;
 import net.Zrips.CMILib.Scoreboards.CMIScoreboard;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.bukkit.scoreboard.DisplaySlot;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class top implements Cmd {
 
@@ -56,11 +57,19 @@ public class top implements Cmd {
 
         int workingIn = Jobs.getUsedSlots(job);
         PageInfo pi = new PageInfo(Jobs.getGCManager().JobsTopAmount, workingIn, page);
+        final int finalPage = page;
+        Bukkit.getScheduler().runTaskAsynchronously(Jobs.getInstance(), () ->showTop(sender, job, pi, finalPage) );
+        return true;
+    }
 
-        List<TopList> fullList = Jobs.getJobsDAO().toplist(job.getName(), pi.getStart());
+    private static void showTop(CommandSender sender, Job job, PageInfo pi, int page) {
+        Player player = (Player) sender;
+        List<TopList> fullList = Jobs.getJobsDAO().toplist(job.getName(), pi.getStart())
+                .stream().filter(topList -> hasToBeSeenInTop(topList, job)).collect(Collectors.toList());
+
         if (fullList.isEmpty()) {
             CMIMessages.sendMessage(sender, LC.info_NoInformation);
-            return true;
+            return;
         }
 
         int place = 1;
@@ -69,15 +78,16 @@ public class top implements Cmd {
             Language.sendMessage(sender, "command.top.output.topline", "%jobname%", job.getName(), "%amount%", Jobs.getGCManager().JobsTopAmount);
 
             for (TopList one : fullList) {
+                System.out.println(one.getPlayerInfo().getName());
                 if (place > Jobs.getGCManager().JobsTopAmount)
                     break;
 
                 Language.sendMessage(sender, "command.top.output.list",
-                    "%number%", ((page - 1) * Jobs.getGCManager().JobsTopAmount) + place,
-                    "%playername%", one.getPlayerInfo().getName(),
-                    "%playerdisplayname%", one.getPlayerInfo().getDisplayName(),
-                    "%level%", one.getLevel(),
-                    "%exp%", one.getExp());
+                        "%number%", ((page - 1) * Jobs.getGCManager().JobsTopAmount) + place,
+                        "%playername%", one.getPlayerInfo().getName(),
+                        "%playerdisplayname%", one.getPlayerInfo().getDisplayName(),
+                        "%level%", one.getLevel(),
+                        "%exp%", one.getExp());
                 place++;
             }
             pi.autoPagination(sender, "jobs top " + job.getName());
@@ -88,7 +98,7 @@ public class top implements Cmd {
                 if (place > Jobs.getGCManager().JobsTopAmount)
                     break;
                 ls.add(Jobs.getLanguage().getMessage("scoreboard.line", "%number%", ((page - 1) * Jobs.getGCManager().JobsTopAmount) + place,
-                    "%playername%", one.getPlayerInfo().getName(), "%playerdisplayname%", one.getPlayerInfo().getDisplayName(), "%level%", one.getLevel()));
+                        "%playername%", one.getPlayerInfo().getName(), "%playerdisplayname%", one.getPlayerInfo().getDisplayName(), "%level%", one.getLevel()));
                 place++;
             }
 
@@ -96,6 +106,16 @@ public class top implements Cmd {
 
             pi.autoPagination(sender, "jobs top " + job.getName());
         }
-        return true;
     }
+
+    private static boolean hasToBeSeenInTop(TopList topList, Job job) {
+        Player player = topList.getPlayerInfo().getJobsPlayer().getPlayer();
+        if (player != null)
+            return !player.hasPermission("jobs.hidetop.*") || !player.hasPermission("jobs.hidetop." + job.getName().toLowerCase());
+        OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(topList.getPlayerInfo().getUuid());
+        return !
+                (Jobs.getVaultPermission().playerHas(null, offlinePlayer, "jobs.hidetop.*")
+                || Jobs.getVaultPermission().playerHas(null, offlinePlayer, "jobs.hidetop." + job.getName().toLowerCase()));
+    }
+
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -232,3 +232,9 @@ permissions:
   jobs.area.remove:
     description: Grants access to the area remove command
     default: op
+  jobs.hidetop.*:
+    description: Prevent player to be shown in all job top
+    default: false
+  jobs.hidegtop:
+    description: Prevent player to be shown in the global jobs top
+    default: false


### PR DESCRIPTION
Add a possibility for a player to be hidden from the jobs tops.

This pull request has made some change to perform that :
 ## Change the way to hook Vault providers :
To check some permission (I'll explain later what), I have to add the provider of permissions. Accessible via `Jobs#getVaultPermission()`. 
To avoid some code repetitions (like logging or checking if Vault is enable) I created the abstract class `HookVault<T>` (where 'T' represent the class of the provider). And make the `HookEconomyTask` extends it. 

## Add 2 new permissions nodes :
- `jobs.hidetop.<job>`: hide the player (if it has the perm) to be shown in the top of the specified job (*replace `<job>` with `*` to hide the player from all jobs top*).
- `jobs.hidegtop` hide the player from the jobs global top.
The two nodes are by default set to `false` for all players.

## Make the use and creation of the list of jobs top asynchronous :
From the creation of the list of all players in the job tops  and the moment where the top is shown to the player that performed the command, all of that is asynchronous.
This has been done because the check of a permission of a offline player (with Vault) has to be asynchronous if the server use LuckPerms and doesn't enable the `vault-unsafe-lookups`. 