### PR TITLE
Fix hunter job payouts not being applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 src/main/resources/locale/messages_en.yml
 .classpath
 .project
+/build/

--- a/pom.xml
+++ b/pom.xml
@@ -226,11 +226,6 @@
 			<!--			 Temporary solution for replacing repository -->
 			<systemPath>${basedir}/libs/mypet-3.11-20210318.180552-1.jar</systemPath>
 		</dependency>
-		<dependency>
-			<groupId>CMILib</groupId>
-			<artifactId>CMILib</artifactId>
-			<version>1.4.3.1</version>
-		</dependency>
 	</dependencies>
 	<repositories>
 		<!-- MythicMobs -->
@@ -293,7 +288,7 @@
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>2.3.1</version>
 				<configuration>
-					<outputDirectory>D:\MC\Server 1.20\plugins\</outputDirectory>
+					<outputDirectory>build/jar</outputDirectory>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -787,7 +787,6 @@ public final class Jobs extends JavaPlugin {
             getDBManager().getDB().triggerTableIdUpdate();
 
             CMIMessages.consoleMessage("&ePlugin has been enabled successfully.");
-            CMIMessages.consoleMessage("&eAAAAAAAAAAAAAAAAAAA");
         } catch (Throwable e) {
             e.printStackTrace();
             System.out.println("There was some issues when starting plugin. Please contact dev about this. Plugin will be disabled.");

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -787,6 +787,7 @@ public final class Jobs extends JavaPlugin {
             getDBManager().getDB().triggerTableIdUpdate();
 
             CMIMessages.consoleMessage("&ePlugin has been enabled successfully.");
+            CMIMessages.consoleMessage("&eAAAAAAAAAAAAAAAAAAA");
         } catch (Throwable e) {
             e.printStackTrace();
             System.out.println("There was some issues when starting plugin. Please contact dev about this. Plugin will be disabled.");


### PR DESCRIPTION
Entities that die after being hit due to non-player means such as fire aspect, cactus, or magma blocks, don't give player payouts.

To fix this, a cache entityLastDamager was created which tracks the last damager of the entity, and is used to set the killer of the entity (Entity#setKiller) when the last damage cause on entity death was not another entity.