### PR TITLE
Fix Job showing empty tops 

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/gtop.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/gtop.java
@@ -6,11 +6,9 @@ import com.gamingmesh.jobs.container.TopList;
 import com.gamingmesh.jobs.i18n.Language;
 import net.Zrips.CMILib.Container.PageInfo;
 import net.Zrips.CMILib.Locale.LC;
-import net.Zrips.CMILib.Logs.CMIDebug;
 import net.Zrips.CMILib.Messages.CMIMessages;
 import net.Zrips.CMILib.Scoreboards.CMIScoreboard;
 import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
-
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -108,7 +106,7 @@ public class gtop implements Cmd {
     private static boolean hasToBeSeenInGlobalTop(TopList topList) {
         Player player = topList.getPlayerInfo().getJobsPlayer().getPlayer();
         if (player != null)
-            return !player.isPermissionSet("jobs.hidegtop");
+            return !player.hasPermission("jobs.hidegtop");
         return !Jobs.getVaultPermission().playerHas(
             null,
             Bukkit.getOfflinePlayer(topList.getPlayerInfo().getUuid()),

--- a/src/main/java/com/gamingmesh/jobs/commands/list/top.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/top.java
@@ -113,7 +113,7 @@ public class top implements Cmd {
     private static boolean hasToBeSeenInTop(TopList topList, Job job) {
         Player player = topList.getPlayerInfo().getJobsPlayer().getPlayer();
         if (player != null)
-            return !player.isPermissionSet("jobs.hidetop.*") || !player.isPermissionSet("jobs.hidetop." + job.getName().toLowerCase());
+            return !(player.hasPermission("jobs.hidetop.*") || player.hasPermission("jobs.hidetop." + job.getName().toLowerCase()));
 
         OfflinePlayer offlinePlayer = Bukkit.getOfflinePlayer(topList.getPlayerInfo().getUuid());
         return !(Jobs.getVaultPermission().playerHas(null, offlinePlayer, "jobs.hidetop.*")


### PR DESCRIPTION
Because of the use of the method `player#isPermissionSet` all players was considered having the nodes `jobs.hidetop.` and `jobs.hidegtop` even if the permission node was unseted. From the commit 613be4780ef3f78abeb25c49be031357f2a1df54.

Fix: #1676