### PR TITLE
Save players after adjusting job progression via commands

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/exp.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/exp.java
@@ -102,20 +102,23 @@ public class exp implements Cmd {
             JobProgression prog = jPlayer.getJobProgression(job);
 
             switch (action) {
-            case Add:
-                int oldLevel = prog.getLevel();
-                if (prog.addExperience(amount))
-                    Jobs.getPlayerManager().performLevelUp(jPlayer, prog.getJob(), oldLevel);
-                break;
-            case Set:
-                prog.setExperience(amount);
-                break;
-            case Take:
-                prog.takeExperience(amount);
-                break;
-            default:
-                break;
+                case Add:
+                    int oldLevel = prog.getLevel();
+                    if (prog.addExperience(amount))
+                        Jobs.getPlayerManager().performLevelUp(jPlayer, prog.getJob(), oldLevel);
+                    break;
+                case Set:
+                    prog.setExperience(amount);
+                    break;
+                case Take:
+                    prog.takeExperience(amount);
+                    break;
+                default:
+                    break;
             }
+
+            jPlayer.setSaved(false);
+            jPlayer.save(true);
 
             Player player = jPlayer.getPlayer();
             if (player == null) {

--- a/src/main/java/com/gamingmesh/jobs/commands/list/level.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/level.java
@@ -110,6 +110,9 @@ public class level implements Cmd {
                     break;
                 }
 
+                jPlayer.setSaved(false);
+                jPlayer.save(true);
+
                 Player player = jPlayer.getPlayer();
                 if (player != null)
                     Language.sendMessage(player, "command.level.output.target", "%jobname%", job.getDisplayName(), "%level%", prog.getLevel(),


### PR DESCRIPTION
Using `/jobs exp` or `/jobs level` while a player is offline appears to not persist after a reboot. This aims to fix that by immediately saving players when either command is executed.