### PR TITLE
Fix NPEs for JobsExpGainEvent

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -1453,7 +1453,8 @@ public final class Jobs extends JavaPlugin {
         payment.set(CurrencyType.MONEY, jobsPrePaymentEvent.getAmount());
         payment.set(CurrencyType.POINTS, jobsPrePaymentEvent.getPoints());
 
-        JobsExpGainEvent jobsExpGainEvent = new JobsExpGainEvent(payment.getOfflinePlayer(), job, expPayment);
+        JobsExpGainEvent jobsExpGainEvent = new JobsExpGainEvent(payment.getOfflinePlayer(), job, expPayment,
+                block, ent, victim, info);
         Bukkit.getServer().getPluginManager().callEvent(jobsExpGainEvent);
         // If event is canceled, don't do anything
         if (jobsExpGainEvent.isCancelled())

--- a/src/main/java/com/gamingmesh/jobs/api/JobsExpGainEvent.java
+++ b/src/main/java/com/gamingmesh/jobs/api/JobsExpGainEvent.java
@@ -24,16 +24,11 @@ public final class JobsExpGainEvent extends BaseEvent implements Cancellable {
 
     private boolean cancelled = false;
 
-    public JobsExpGainEvent(OfflinePlayer offlinePlayer, Job job, double exp) {
-	this.offlinePlayer = offlinePlayer;
-	this.job = job;
-	this.exp = exp;
-    }
-
     public JobsExpGainEvent(OfflinePlayer offlinePlayer, Job job, double exp, Block block,
 		Entity entity, LivingEntity living, ActionInfo info) {
-	this(offlinePlayer, job, exp);
-
+    this.offlinePlayer = offlinePlayer;
+    this.job = job;
+    this.exp = exp;
 	this.block = block;
 	this.entity = entity;
 	this.living = living;


### PR DESCRIPTION
This was throwing NPEs due to the wrong constructor being used in Jobs#perform. After fixing this, the old constructor could safely be removed so I did that.