### PR TITLE
Fix all players reload caused by limit loading

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -23,7 +23,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -160,7 +159,7 @@ public final class Jobs extends JavaPlugin {
     private GuiManager guiManager;
 
     private static JobsDAO dao;
-    private static List<Job> jobs = new ArrayList<Job>();
+    private static List<Job> jobs = new ArrayList<>();
     private static Job noneJob;
     private static Map<Job, Integer> usedSlots = new WeakHashMap<>();
 
@@ -551,8 +550,7 @@ public final class Jobs extends JavaPlugin {
         Map<Integer, Map<String, Log>> playersLogs = dao.getAllLogs();
         Map<Integer, ArchivedJobs> playersArchives = dao.getAllArchivedJobs();
         Map<Integer, PaymentData> playersLimits = dao.loadPlayerLimits();
-        for (Iterator<PlayerInfo> it = temp.values().iterator(); it.hasNext();) {
-            PlayerInfo one = it.next();
+        for (PlayerInfo one : temp.values()) {
             int id = one.getID();
             JobsPlayer jPlayer = getPlayerManager().getJobsPlayerOffline(
                 one,

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -328,7 +328,6 @@ public class PlayerManager {
 
         playersUUID.values().removeIf(jPlayer -> jPlayer.isSaved() && !jPlayer.isOnline());
 
-        System.out.println("Saved all players");
         Jobs.getBpManager().saveCache();
     }
 

--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -1,17 +1,17 @@
 /**
  * Jobs Plugin for Bukkit
  * Copyright (C) 2011 Zak Ford <zak.j.ford@gmail.com>
- *
+ * <p>
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- *
+ * <p>
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- *
+ * <p>
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -120,7 +120,7 @@ public class PlayerManager {
             int id = playerUUIDMap.get(info.getUuid()).getID();
             if (Jobs.getGCManager().isInformDuplicates()) {
                 CMIMessages.consoleMessage("&7Duplicate! &5" + info.getName() + " &7same UUID for 2 entries in database. Please remove of one them from users table id1: &2" + id + " &7id2: &2" + info
-                    .getID());
+                        .getID());
             }
             if (id < info.getID()) {
                 return;
@@ -322,11 +322,13 @@ public class PlayerManager {
          * 2) Perform save on all players on copied list.
          * 3) Garbage collect the real list to remove any offline players with saved data
          */
-        for (JobsPlayer jPlayer : new ArrayList<>(playersUUID.values()))
+        for (JobsPlayer jPlayer : new ArrayList<>(playersUUID.values())) {
             jPlayer.save();
+        }
 
         playersUUID.values().removeIf(jPlayer -> jPlayer.isSaved() && !jPlayer.isOnline());
 
+        System.out.println("Saved all players");
         Jobs.getBpManager().saveCache();
     }
 
@@ -383,7 +385,7 @@ public class PlayerManager {
      * This can return null sometimes if the given player
      * is not cached into memory.
      *
-     * @param player the player uuid
+     * @param uuid the player uuid
      * @return {@link JobsPlayer} the player job info of the player
      */
     public JobsPlayer getJobsPlayer(UUID uuid) {
@@ -397,7 +399,7 @@ public class PlayerManager {
      * This can return null sometimes if the given player
      * is not cached into memory.
      *
-     * @param player name - the player name who's job you're getting
+     * @param playerName - the player name who's job you're getting
      * @return {@link JobsPlayer} the player job info of the player
      */
     public JobsPlayer getJobsPlayer(String playerName) {
@@ -416,7 +418,7 @@ public class PlayerManager {
      * @return {@link JobsPlayer}
      */
     public JobsPlayer getJobsPlayerOffline(PlayerInfo info, List<JobsDAOData> jobs, PlayerPoints points,
-        Map<String, Log> logs, ArchivedJobs archivedJobs, PaymentData limits) {
+                                           Map<String, Log> logs, ArchivedJobs archivedJobs, PaymentData limits) {
         if (info == null)
             return null;
 
@@ -440,11 +442,11 @@ public class PlayerManager {
                     }
 
                     jPlayer.progression.add(new JobProgression(job, jPlayer, jobdata.getLevel(), jobdata.getExperience()));
-                    jPlayer.reloadMaxExperience();
-                    jPlayer.reloadLimits();
                 }
             }
         }
+
+        jPlayer.reloadMaxExperience();
 
         if (points != null)
             jPlayer.setPoints(points);
@@ -732,17 +734,17 @@ public class PlayerManager {
 
         // LevelUp event
         JobsLevelUpEvent levelUpEvent = new JobsLevelUpEvent(
-            jPlayer,
-            job,
-            prog.getLevel(),
-            Jobs.getTitleManager().getTitle(oldLevel, prog.getJob().getName()),
-            Jobs.getTitleManager().getTitle(prog.getLevel(), prog.getJob().getName()),
-            Jobs.getGCManager().SoundLevelupSound,
-            Jobs.getGCManager().SoundLevelupVolume,
-            Jobs.getGCManager().SoundLevelupPitch,
-            Jobs.getGCManager().SoundTitleChangeSound,
-            Jobs.getGCManager().SoundTitleChangeVolume,
-            Jobs.getGCManager().SoundTitleChangePitch);
+                jPlayer,
+                job,
+                prog.getLevel(),
+                Jobs.getTitleManager().getTitle(oldLevel, prog.getJob().getName()),
+                Jobs.getTitleManager().getTitle(prog.getLevel(), prog.getJob().getName()),
+                Jobs.getGCManager().SoundLevelupSound,
+                Jobs.getGCManager().SoundLevelupVolume,
+                Jobs.getGCManager().SoundLevelupPitch,
+                Jobs.getGCManager().SoundTitleChangeSound,
+                Jobs.getGCManager().SoundTitleChangeVolume,
+                Jobs.getGCManager().SoundTitleChangePitch);
 
         plugin.getServer().getPluginManager().callEvent(levelUpEvent);
 
@@ -753,7 +755,7 @@ public class PlayerManager {
         if (player != null && Jobs.getGCManager().SoundLevelupUse) {
             try {
                 player.getWorld().playSound(player.getLocation(), levelUpEvent.getSound(),
-                    levelUpEvent.getSoundVolume(), levelUpEvent.getSoundPitch());
+                        levelUpEvent.getSoundVolume(), levelUpEvent.getSoundPitch());
             } catch (Exception e) { // If it fails, we can ignore it
             }
         }
@@ -774,27 +776,27 @@ public class PlayerManager {
                         Type type = Type.BALL;
 
                         switch (rt) {
-                        case 2:
-                            type = Type.BALL_LARGE;
-                            break;
-                        case 3:
-                            type = Type.BURST;
-                            break;
-                        case 4:
-                            type = Type.CREEPER;
-                            break;
-                        case 5:
-                            type = Type.STAR;
-                            break;
-                        default:
-                            break;
+                            case 2:
+                                type = Type.BALL_LARGE;
+                                break;
+                            case 3:
+                                type = Type.BURST;
+                                break;
+                            case 4:
+                                type = Type.CREEPER;
+                                break;
+                            case 5:
+                                type = Type.STAR;
+                                break;
+                            default:
+                                break;
                         }
 
                         Color c1 = Util.getColor(r.nextInt(17) + 1);
                         Color c2 = Util.getColor(r.nextInt(17) + 1);
 
                         FireworkEffect effect = FireworkEffect.builder().flicker(r.nextBoolean()).withColor(c1)
-                            .withFade(c2).with(type).trail(r.nextBoolean()).build();
+                                .withFade(c2).with(type).trail(r.nextBoolean()).build();
                         fm.addEffect(effect);
 
                         fm.setPower(r.nextInt(2) + 1);
@@ -809,13 +811,13 @@ public class PlayerManager {
         }
 
         String message = Jobs.getLanguage().getMessage("message.levelup." + (Jobs.getGCManager().isBroadcastingLevelups()
-            ? "broadcast" : "nobroadcast"));
+                ? "broadcast" : "nobroadcast"));
 
         message = Language.updateJob(message, job);
 
         if (levelUpEvent.getOldTitle() != null)
             message = message.replace("%titlename%", levelUpEvent.getOldTitle()
-                .getChatColor().toString() + levelUpEvent.getOldTitle().getName());
+                    .getChatColor().toString() + levelUpEvent.getOldTitle().getName());
 
         message = message.replace("%playername%", jPlayer.getName());
         message = message.replace("%playerdisplayname%", jPlayer.getDisplayName());
@@ -825,7 +827,7 @@ public class PlayerManager {
             for (String line : message.split("\n")) {
                 if (Jobs.getGCManager().isBroadcastingLevelups()) {
                     if (Jobs.getGCManager().BroadcastingLevelUpLevels.contains(oldLevel + 1)
-                        || Jobs.getGCManager().BroadcastingLevelUpLevels.contains(0))
+                            || Jobs.getGCManager().BroadcastingLevelUpLevels.contains(0))
                         plugin.getComplement().broadcastMessage(line);
                 } else if (player != null) {
                     if (Jobs.getGCManager().LevelChangeActionBar)
@@ -841,19 +843,19 @@ public class PlayerManager {
             if (player != null && Jobs.getGCManager().SoundTitleChangeUse) {
                 try {
                     player.getWorld().playSound(player.getLocation(), levelUpEvent.getTitleChangeSound(), levelUpEvent.getTitleChangeVolume(),
-                        levelUpEvent.getTitleChangePitch());
+                            levelUpEvent.getTitleChangePitch());
                 } catch (Exception e) { // If it fails, we can ignore it
                 }
             }
 
             // user would skill up
             message = Jobs.getLanguage().getMessage("message.skillup." + (Jobs.getGCManager().isBroadcastingSkillups()
-                ? "broadcast" : "nobroadcast"));
+                    ? "broadcast" : "nobroadcast"));
 
             message = message.replace("%playername%", jPlayer.getName());
             message = message.replace("%playerdisplayname%", jPlayer.getDisplayName());
             message = message.replace("%titlename%", levelUpEvent.getNewTitle()
-                .getChatColor().toString() + levelUpEvent.getNewTitle().getName());
+                    .getChatColor().toString() + levelUpEvent.getNewTitle().getName());
 
             message = Language.updateJob(message, job);
 
@@ -909,8 +911,6 @@ public class PlayerManager {
      * Performs command on level up
      *
      * @param jPlayer {@link JobsPlayer}
-     * @param job {@link Job}
-     * @param oldLevel
      */
     public void performCommandOnLevelUp(JobsPlayer jPlayer, JobProgression prog, int oldLevel) {
         int newLevel = oldLevel + 1;
@@ -924,9 +924,9 @@ public class PlayerManager {
             if ((command.getLevelFrom() == 0 && command.getLevelUntil() == 0) || (newLevel >= command.getLevelFrom() && newLevel <= command.getLevelUntil())) {
                 for (String commandString : new ArrayList<>(command.getCommands())) {
                     commandString = commandString.replace("[player]", jPlayer.getName())
-                        .replace("[playerName]", jPlayer.getName())
-                        .replace("[oldlevel]", Integer.toString(newLevel - 1))
-                        .replace("[newlevel]", Integer.toString(newLevel));
+                            .replace("[playerName]", jPlayer.getName())
+                            .replace("[oldlevel]", Integer.toString(newLevel - 1))
+                            .replace("[newlevel]", Integer.toString(newLevel));
 
                     commandString = Language.updateJob(commandString, prog.getJob());
 
@@ -956,7 +956,7 @@ public class PlayerManager {
     /**
      * Checks whenever the given jobs player is under the max allowed jobs.
      *
-     * @param player {@link JobsPlayer}
+     * @param jPlayer {@link JobsPlayer}
      * @param currentCount the current jobs size
      * @return true if the player is under the given jobs size
      */
@@ -1050,7 +1050,7 @@ public class PlayerManager {
         if (Jobs.getGCManager().boostedItemsInMainHand) {
             ItemStack iih = CMIItemStack.getItemInMainHand(player);
             if (iih != null && Jobs.getGCManager().boostedItemsSlotSpecific && (!CMIMaterial.isArmor(iih.getType()) || CMIMaterial.isShield(iih.getType())) || !Jobs
-                .getGCManager().boostedItemsSlotSpecific) {
+                    .getGCManager().boostedItemsSlotSpecific) {
                 jitems.add(getJobsItemByNbt(CMIItemStack.getItemInMainHand(player)));
             }
         }
@@ -1059,7 +1059,7 @@ public class PlayerManager {
         if (Version.isCurrentEqualOrHigher(Version.v1_9_R1) && Jobs.getGCManager().boostedItemsInOffHand) {
             ItemStack iih = CMIItemStack.getItemInOffHand(player);
             if (iih != null && Jobs.getGCManager().boostedItemsSlotSpecific && (!CMIMaterial.isArmor(iih.getType()) || CMIMaterial.isShield(iih.getType())) || !Jobs
-                .getGCManager().boostedItemsSlotSpecific) {
+                    .getGCManager().boostedItemsSlotSpecific) {
                 jitems.add(getJobsItemByNbt(player.getInventory().getItemInOffHand()));
             }
         }
@@ -1091,7 +1091,7 @@ public class PlayerManager {
 
                     // Helmet slot
                     if (i == 3 && !CMIMaterial.isArmor(item.getType()) && (CMIMaterial.isWeapon(item.getType()) || CMIMaterial.isTool(item.getType())) || i == 3 && CMIMaterial.isArmor(item.getType())
-                        && !CMIMaterial.isHelmet(item.getType())) {
+                            && !CMIMaterial.isHelmet(item.getType())) {
                         continue;
                     }
                 }

--- a/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
@@ -1410,12 +1410,12 @@ public class JobsPlayer {
      */
     @Deprecated
     public int getMaxBrewingStandsAllowed() {
-        Double maxV = Jobs.getPermissionManager().getMaxPermission(this, "jobs.maxbrewingstands");
+        double maxV = Jobs.getPermissionManager().getMaxPermission(this, "jobs.maxbrewingstands");
 
         if (maxV == 0)
-            maxV = (double) Jobs.getGCManager().getBrewingStandsMaxDefault();
+            maxV = Jobs.getGCManager().getBrewingStandsMaxDefault();
 
-        return maxV.intValue();
+        return (int) maxV;
     }
 
     /**


### PR DESCRIPTION
On server start, all players are loaded, including their limits. This causes JobsPlayer of every player to be marked as unsaved (See [this issue](https://github.com/Zrips/Jobs/issues/1741)).
I don't think it's necessary to preload player limits, as it is loaded on player join.