### PR TITLE
Add gain exp by returning a fireball from a ghast

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1306,6 +1306,8 @@ public final class JobsPaymentListener implements Listener {
 
         if (!(event.getEntity().getLastDamageCause() instanceof EntityDamageByEntityEvent)) {
             killer = entityLastDamager.getIfPresent(event.getEntity().getUniqueId());
+        } else if(event.getEntity().getLastDamageCause().getCause() == EntityDamageEvent.DamageCause.PROJECTILE) {
+            killer = event.getEntity().getLastDamageCause().getDamageSource().getCausingEntity();
         } else {
             killer = ((EntityDamageByEntityEvent) event.getEntity().getLastDamageCause()).getDamager();
         }


### PR DESCRIPTION
When a player hit a fireball from a ghast and kill him, it'll give the kill to the player and gain exp.