### PR TITLE
Fix NullPointerException when generating payment message

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentVisualizationListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentVisualizationListener.java
@@ -1,17 +1,17 @@
 /**
  * Jobs Plugin for Bukkit
  * Copyright (C) 2011 Zak Ford <zak.j.ford@gmail.com>
- * 
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -110,45 +110,45 @@ public class JobsPaymentVisualizationListener implements Listener {
             return;
 
         if (!Jobs.getGeneralConfigManager().ActionBarEnabled) {
-            showChatMessage(player, event.getPayment());
+            showChatMessage(player, event);
             return;
         }
 
         MessageToggleState state = ToggleBarHandling.getActionBarState(event.getPlayer().getUniqueId());
 
         if (!state.equals(MessageToggleState.Batched)) {
-            showChatMessage(player, event.getPayment());
+            showChatMessage(player, event);
             return;
         }
 
-        String message = generateDelayedMessage(event.getPayment());
+        String message = generateDelayedMessage(event);
         if (!message.isEmpty())
             CMIActionBar.send(player, message);
         return;
     }
 
-    private static void showChatMessage(Player player, Map<CurrencyType, Double> payment) {
+    private static void showChatMessage(Player player, JobsPaymentEvent event) {
         MessageToggleState chatState = ToggleBarHandling.getChatTextState(player.getUniqueId());
         if (chatState.equals(MessageToggleState.Off))
             return;
-        String message = generateDelayedMessage(payment);
+        String message = generateDelayedMessage(event);
 
         if (!message.isEmpty())
             player.sendMessage(message);
     }
 
-    private static String generateDelayedMessage(Map<CurrencyType, Double> payment) {
+    private static String generateDelayedMessage(JobsPaymentEvent event) {
 
         String message = Jobs.getLanguage().getMessage("command.toggle.output.paid.main");
-        double money = payment.get(CurrencyType.MONEY);
+        double money = event.get(CurrencyType.MONEY);
         if (money != 0D)
             message += " " + Jobs.getLanguage().getMessage("command.toggle.output.paid.money", "[amount]", String.format(Jobs.getGCManager().getDecimalPlacesMoney(), money));
 
-        double points = payment.get(CurrencyType.POINTS);
+        double points = event.get(CurrencyType.POINTS);
         if (points != 0D)
             message += " " + Jobs.getLanguage().getMessage("command.toggle.output.paid.points", "[points]", String.format(Jobs.getGCManager().getDecimalPlacesPoints(), points));
 
-        double exp = payment.get(CurrencyType.EXP);
+        double exp = event.get(CurrencyType.EXP);
         if (exp != 0D)
             message += " " + Jobs.getLanguage().getMessage("command.toggle.output.paid.exp", "[exp]", String.format(Jobs.getGCManager().getDecimalPlacesExp(), exp));
 


### PR DESCRIPTION
The recent jobs version 5.2.4.3 throws errors into the server log:

```
[21:40:11 ERROR]: Could not pass event JobsPaymentEvent to Jobs v5.2.4.3-CORP
java.lang.NullPointerException: Cannot invoke "java.lang.Double.doubleValue()" because the return value of "java.util.Map.get(Object)" is null
        at com.gamingmesh.jobs.listeners.JobsPaymentVisualizationListener.generateDelayedMessage(JobsPaymentVisualizationListener.java:147) ~[Jobs5.2.4.3.
jar:?]
        at com.gamingmesh.jobs.listeners.JobsPaymentVisualizationListener.showBatchedActionBarChatMessage(JobsPaymentVisualizationListener.java:124) ~[Job
s5.2.4.3.jar:?]
        at com.gamingmesh.jobs.listeners.JobsPaymentVisualizationListener.onJobsPaymentEvent(JobsPaymentVisualizationListener.java:99) ~[Jobs5.2.4.3.jar:?]
        at com.destroystokyo.paper.event.executor.asm.generated.GeneratedEventExecutor526.execute(Unknown Source) ~[?:?]
        at org.bukkit.plugin.EventExecutor$2.execute(EventExecutor.java:77) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        at co.aikar.timings.TimedEventExecutor.execute(TimedEventExecutor.java:77) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:git-Paper-497]
        at org.bukkit.plugin.RegisteredListener.callEvent(RegisteredListener.java:70) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        at io.papermc.paper.plugin.manager.PaperEventManager.callEvent(PaperEventManager.java:54) ~[paper-1.20.4.jar:git-Paper-497]
        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.callEvent(PaperPluginManagerImpl.java:126) ~[paper-1.20.4.jar:git-Paper-497]
        at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:615) ~[paper-api-1.20.4-R0.1-SNAPSHOT.jar:?]
        at com.gamingmesh.jobs.economy.BufferedEconomy.payAll(BufferedEconomy.java:206) ~[Jobs5.2.4.3.jar:?]
        at com.gamingmesh.jobs.tasks.BufferedPaymentThread.run(BufferedPaymentThread.java:52) ~[Jobs5.2.4.3.jar:?]
```

Payments may not always contain each of money/points/exp, so the Map being accessed in `JobsPaymentVisualizationListener#generateDelayedMessage` can return `null` on `double points = payment.get(CurrencyType.POINTS)`, throwing a `NullPointerException` because `null` cannot be converted to `double`.

I fixed it by using `JobsPaymentEvent#get` which already checks for that case.