### PR TITLE
Fixes 2 issues with the restricted areas

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/area.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/area.java
@@ -73,10 +73,15 @@ public class area implements Cmd {
                     name = protectedRegion.getId();
                 }
 
-                if (!wg)
-                    ra.addNew(new RestrictedArea(name, Jobs.getSelectionManager().getSelectionCuboid(player), bonus), true);
-                else
-                    ra.addNew(new RestrictedArea(name, name, bonus), true);
+                if (!wg) {
+                    RestrictedArea restrictedArea = new RestrictedArea(name, Jobs.getSelectionManager().getSelectionCuboid(player), bonus);
+                    restrictedArea.setEnabled(true);
+                    ra.addNew(restrictedArea, true);
+                } else {
+                    RestrictedArea restrictedArea = new RestrictedArea(name, name, bonus);
+                    restrictedArea.setEnabled(true);
+                    ra.addNew(restrictedArea, true);
+                }
                 Language.sendMessage(sender, "command.area.output.addedNew", "%bonus%", bonus);
                 return true;
             }

--- a/src/main/java/com/gamingmesh/jobs/config/RestrictedAreaManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/RestrictedAreaManager.java
@@ -111,7 +111,7 @@ public class RestrictedAreaManager {
             conf.set("restrictedareas." + areaKey + ".enabled", area.isEnabled());
 
             for (Entry<CurrencyType, Double> one : area.getMultipliers().entrySet()) {
-                conf.set("restrictedareas." + areaKey + ".multipliers." + one.getKey(), one.getValue());
+                conf.set("restrictedareas." + areaKey + ".multipliers." + CMIText.firstToUpperCase(one.getKey().name()), one.getValue());
             }
 
             if (area.getWgName() == null) {


### PR DESCRIPTION
This PR fixes 2 issues I came across whilst trying to use the restricted area feature:
- Newly created areas will be enabled by default, since it is quite annoying to enable them first in the config, since there is currently no way of enabling/disabling them via command.
- Newly created areas were saved with the incorrect capitalization of the multiplier currency enum values. This lead to them not being loaded correctly after a restart or using the reload command.