### PR TITLE
Fix missing player name argument in pagination command

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
@@ -337,7 +337,7 @@ public class JobsCommands implements CommandExecutor {
             if (sender.getName().equalsIgnoreCase(pName))
                 pi.autoPagination(sender, LABEL + " " + info.class.getSimpleName() + " " + job.getName() + t);
             else
-                pi.autoPagination(sender, LABEL + " " + playerinfo.class.getSimpleName() + " " + job.getName() + t);
+                pi.autoPagination(sender, LABEL + " " + playerinfo.class.getSimpleName() + " " + pName + " " + job.getName() + t);
         }
     }
 


### PR DESCRIPTION
The player name argument was missing from the pagination buttons of the `playerinfo` command, leading to them not functioning correctly.