### PR TITLE
Add Compatibility with CustomFishing

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -28,17 +28,20 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Random;
 import java.util.UUID;
 import java.util.WeakHashMap;
 import java.util.logging.Logger;
 
+import com.gamingmesh.jobs.listeners.*;
 import org.bukkit.Bukkit;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.plugin.Plugin;
+import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.gamingmesh.jobs.Gui.GuiManager;
@@ -96,15 +99,6 @@ import com.gamingmesh.jobs.economy.Economy;
 import com.gamingmesh.jobs.economy.PaymentData;
 import com.gamingmesh.jobs.hooks.HookManager;
 import com.gamingmesh.jobs.i18n.Language;
-import com.gamingmesh.jobs.listeners.JobsListener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_14Listener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_16Listener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_20Listener;
-import com.gamingmesh.jobs.listeners.JobsPayment1_9Listener;
-import com.gamingmesh.jobs.listeners.JobsPaymentListener;
-import com.gamingmesh.jobs.listeners.JobsPaymentVisualizationListener;
-import com.gamingmesh.jobs.listeners.PistonProtectionListener;
-import com.gamingmesh.jobs.listeners.PlayerSignEdit1_20Listeners;
 import com.gamingmesh.jobs.selection.SelectionManager;
 import com.gamingmesh.jobs.stuff.Loging;
 import com.gamingmesh.jobs.stuff.TabComplete;
@@ -250,7 +244,7 @@ public final class Jobs extends JavaPlugin {
         return Optional.empty();
     }
 
-    public void removeBlockOwnerShip(org.bukkit.block.Block block) {
+    public void removeBlockOwnerShip(Block block) {
         BlockOwnerShip ship = blockOwnerShipsMaterial.get(CMIMaterial.get(block));
         if (ship != null)
             ship.remove(block);
@@ -273,7 +267,7 @@ public final class Jobs extends JavaPlugin {
     }
 
     private boolean setupPlaceHolderAPI() {
-        org.bukkit.plugin.Plugin papi = getServer().getPluginManager().getPlugin("PlaceholderAPI");
+        Plugin papi = getServer().getPluginManager().getPlugin("PlaceholderAPI");
         if (papi == null || !papi.isEnabled())
             return false;
 
@@ -752,7 +746,7 @@ public final class Jobs extends JavaPlugin {
 
         try {
             Class.forName("net.kyori.adventure.text.Component");
-            org.bukkit.inventory.meta.ItemMeta.class.getDeclaredMethod("displayName");
+            ItemMeta.class.getDeclaredMethod("displayName");
             kyoriSupported = true;
         } catch (NoSuchMethodException | ClassNotFoundException e) {
         }
@@ -817,10 +811,15 @@ public final class Jobs extends JavaPlugin {
 
         CMIMessages.consoleMessage("&eRegistering listeners...");
 
-        org.bukkit.plugin.PluginManager pm = getInstance().getServer().getPluginManager();
-
+        PluginManager pm = getInstance().getServer().getPluginManager();
+        if (getGCManager().useCustomFishingOnly) {
+            pm.registerEvents(new JobsCustomFishingPaymentListener(), getInstance());
+        } else {
+            pm.registerEvents(new JobsDefaultFishPaymentListener(), getInstance());
+        }
         pm.registerEvents(new JobsListener(getInstance()), getInstance());
         pm.registerEvents(new JobsPaymentListener(getInstance()), getInstance());
+
         pm.registerEvents(new JobsPaymentVisualizationListener(getInstance()), getInstance());
 
         if (Version.isCurrentEqualOrHigher(Version.v1_9_R1))
@@ -845,6 +844,9 @@ public final class Jobs extends JavaPlugin {
 
         if (HookManager.checkPyroFishingPro()) {
             HookManager.getPyroFishingProManager().registerListener();
+        }
+        if (HookManager.checkCustomFishing()) {
+            HookManager.getCustomFishingManager().registerListener();
         }
         if (HookManager.getMcMMOManager().CheckmcMMO()) {
             HookManager.setMcMMOlistener();

--- a/src/main/java/com/gamingmesh/jobs/actions/CustomFishingInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/CustomFishingInfo.java
@@ -1,0 +1,23 @@
+package com.gamingmesh.jobs.actions;
+
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.container.BaseActionInfo;
+
+public class CustomFishingInfo extends BaseActionInfo {
+    private final String name;
+
+    public CustomFishingInfo(String name, ActionType type) {
+        super(type);
+        this.name = name;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String getNameWithSub() {
+        return name;
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -385,6 +385,9 @@ public class ConfigManager {
         cfg.addComment(pt + ".PyroFishingPro", "Catching CUSTOM fish of the PyroFishingPro plugin");
         generate(cfg, pt + ".PyroFishingPro.CustomTier");
 
+        cfg.addComment(pt + ".CustomFishing", "Catching CUSTOM fish of the CustomFishing plugin");
+        generate(cfg, pt + ".CustomFishing.CustomFishId");
+
         cfg.addComment(pt + ".Repair", "Repairing items");
         generate(cfg, pt + ".Repair.wood_sword");
         generate(cfg, pt + ".Repair.iron_sword");
@@ -595,6 +598,7 @@ public class ConfigManager {
         case MILK:
         case MMKILL:
         case PYROFISHINGPRO:
+        case CUSTOMFISHING:
         case BREED:
         case TAME:
         case SHEAR:
@@ -796,7 +800,8 @@ public class ConfigManager {
             type = cmiEnchant != null ? cmiEnchant.getKeyName() : myKey;
 
         } else if (actionType == ActionType.CUSTOMKILL || actionType == ActionType.COLLECT || actionType == ActionType.MMKILL
-            || actionType == ActionType.BAKE || actionType == ActionType.SMELT || actionType == ActionType.PYROFISHINGPRO) {
+            || actionType == ActionType.BAKE || actionType == ActionType.SMELT || actionType == ActionType.PYROFISHINGPRO
+            || actionType == ActionType.CUSTOMFISHING) {
             type = myKey;
         } else if (actionType == ActionType.EXPLORE) {
             type = myKey;

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -40,7 +40,6 @@ import com.gamingmesh.jobs.container.CurrencyType;
 import com.gamingmesh.jobs.container.MessageToggleState;
 
 import net.Zrips.CMILib.CMILib;
-import net.Zrips.CMILib.Container.CMIArray;
 import net.Zrips.CMILib.Container.CMIList;
 import net.Zrips.CMILib.Container.CMINumber;
 import net.Zrips.CMILib.Enchants.CMIEnchantment;
@@ -113,7 +112,7 @@ public class GeneralConfigManager {
         BossBarEnabled = false, ActionBarEnabled, ExploreCompact, ExploreSaveIntoDatabase = false, DBCleaningJobsUse, DBCleaningUsersUse,
         DisabledWorldsUse, UseAsWhiteListWorldList, MythicMobsEnabled,
         LoggingUse, payForCombiningItems, BlastFurnacesReassign = false, SmokerReassign = false, payForStackedEntities, payForAbove = false,
-        payForEachVTradeItem, allowEnchantingBoostedItems, preventShopItemEnchanting;
+        payForEachVTradeItem, allowEnchantingBoostedItems, preventShopItemEnchanting, useCustomFishingOnly = false;
     public MessageToggleState BossBarsMessageDefault = MessageToggleState.Rapid;
     public MessageToggleState ActionBarsMessageDefault = MessageToggleState.Rapid;
     public MessageToggleState ChatTextMessageDefault = MessageToggleState.Batched;
@@ -961,6 +960,9 @@ public class GeneralConfigManager {
 
         c.addComment("ExploitProtections.MythicMobs", "MythicMobs plugin support", "Disable if you having issues with it or using old version");
         MythicMobsEnabled = c.get("ExploitProtections.MythicMobs.enabled", true);
+
+        c.addComment("ExploitProtections.CustomFishing", "CustomFishing plugin support (Optional)", "If setting is enabled, Fish and PyroFishingPro actions are disabled and only CustomFishing action is enabled.", "Leave it disabled if you're not experiencing issues because of CustomFishing Plugin.");
+        useCustomFishingOnly = c.get("ExploitProtections.CustomFishing.Use-CustomFishing-Only", false);
 
         // Only applies for older versions.
         if (Version.isCurrentLower(Version.v1_14_R1)) {

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -389,6 +389,8 @@ public class LanguageManager {
             c.get("command.info.output.fish.none", "%jobname% does not get money from fishing.");
             c.get("command.info.output.pyrofishingpro.info", "&eFish");
             c.get("command.info.output.pyrofishingpro.none", "%jobname% does not get money from fishing.");
+            c.get("command.info.output.customfishing.info", "&eFish");
+            c.get("command.info.output.customfishing.none", "%jobname% does not get money from fishing.");
             c.get("command.info.output.craft.info", "&eCraft");
             c.get("command.info.output.craft.none", "%jobname% does not get money from crafting.");
             c.get("command.info.output.smelt.info", "&eSmelt");

--- a/src/main/java/com/gamingmesh/jobs/container/ActionType.java
+++ b/src/main/java/com/gamingmesh/jobs/container/ActionType.java
@@ -29,6 +29,7 @@ public enum ActionType {
     MMKILL("MMKill"),
     FISH(),
     PYROFISHINGPRO("PyroFishingPro"),
+    CUSTOMFISHING("CustomFishing"),
     CRAFT(),
     VTRADE("VTrade"),
     SMELT(),

--- a/src/main/java/com/gamingmesh/jobs/hooks/CustomFishing/CustomFishingManager.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/CustomFishing/CustomFishingManager.java
@@ -1,0 +1,36 @@
+package com.gamingmesh.jobs.hooks.CustomFishing;
+
+import com.gamingmesh.jobs.Jobs;
+import net.momirealms.customfishing.api.event.FishingLootSpawnEvent;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class CustomFishingManager implements Listener {
+    private static String lastFishId;
+    private static long time = 0;
+    private final Jobs jobs;
+
+    public CustomFishingManager() {
+        this.jobs = Jobs.getInstance();
+        registerListener();
+    }
+
+    @EventHandler(priority = EventPriority.LOW, ignoreCancelled = true)
+    public void onFishingLootSpawn(FishingLootSpawnEvent event) {
+        lastFishId = event.getLoot().id();
+        time = System.currentTimeMillis();
+    }
+
+    public static String getLastFishId() {
+        if (time + 60 < System.currentTimeMillis())
+            return null;
+        return lastFishId;
+    }
+
+    public void registerListener() {
+        if (Jobs.getGCManager().useCustomFishingOnly) {
+            jobs.getServer().getPluginManager().registerEvents(this, jobs);
+        }
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/hooks/HookManager.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/HookManager.java
@@ -1,5 +1,6 @@
 package com.gamingmesh.jobs.hooks;
 
+import com.gamingmesh.jobs.hooks.CustomFishing.CustomFishingManager;
 import com.gamingmesh.jobs.hooks.blockTracker.BlockTrackerManager;
 import com.gamingmesh.jobs.hooks.pyroFishingPro.PyroFishingProManager;
 import org.bukkit.plugin.PluginManager;
@@ -29,6 +30,7 @@ public class HookManager {
     private static WildStackerHandler wildStackerHandler;
     private static BlockTrackerManager blockTrackerManager;
     private static PyroFishingProManager pyroFishingProManager;
+    private static CustomFishingManager customFishingManager;
 
     private static final Jobs PLUGIN = JavaPlugin.getPlugin(Jobs.class);
 
@@ -45,6 +47,7 @@ public class HookManager {
             setWildStackerHandler();
             setBlockTrackerManager();
             setPyroFishingProManager();
+            setCustomFishingManager();
         });
     }
 
@@ -98,12 +101,23 @@ public class HookManager {
         return pyroFishingProManager;
     }
 
+    public static CustomFishingManager getCustomFishingManager() {
+        if (customFishingManager == null)
+            customFishingManager = new CustomFishingManager();
+
+        return customFishingManager;
+    }
+
     public static boolean checkMythicMobs() {
         return Jobs.getGCManager().MythicMobsEnabled && MythicManager != null && MythicManager.check();
     }
 
     public static boolean checkPyroFishingPro() {
         return pyroFishingProManager != null;
+    }
+
+    public static boolean checkCustomFishing() {
+        return customFishingManager != null;
     }
 
     public static BlockTrackerManager getBlockTrackerManager() {
@@ -180,6 +194,17 @@ public class HookManager {
         if (JobsHook.PyroFishingPro.isEnabled()) {
             pyroFishingProManager = new PyroFishingProManager();
             CMIMessages.consoleMessage("&e" + JobsHook.PyroFishingPro + " detected.");
+        }
+    }
+
+    private static void setCustomFishingManager() {
+        if (JobsHook.CustomFishing.isEnabled()) {
+            customFishingManager = new CustomFishingManager();
+            if (Jobs.getGCManager().useCustomFishingOnly) {
+                CMIMessages.consoleMessage("&e" + JobsHook.CustomFishing + " detected. (Using CustomFishing-Only Settings)");
+            } else {
+                CMIMessages.consoleMessage("&e" + JobsHook.CustomFishing + " detected. (Not using CustomFishing-Only Settings)");
+            }
         }
     }
 }

--- a/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
@@ -12,7 +12,8 @@ public enum JobsHook {
     MythicMobs,
     mcMMO,
     BlockTracker,
-    PyroFishingPro;
+    PyroFishingPro,
+    CustomFishing;
 
     private Boolean enabled;
     private Boolean present;

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsCustomFishingPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsCustomFishingPaymentListener.java
@@ -1,0 +1,58 @@
+package com.gamingmesh.jobs.listeners;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.actions.CustomFishingInfo;
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.hooks.CustomFishing.CustomFishingManager;
+import com.gamingmesh.jobs.hooks.JobsHook;
+import com.gmail.nossr50.config.experience.ExperienceConfig;
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+import com.gmail.nossr50.util.player.UserManager;
+import net.momirealms.customfishing.api.event.FishingLootSpawnEvent;
+import net.momirealms.customfishing.api.mechanic.loot.LootType;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+public class JobsCustomFishingPaymentListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerCustomFishing(FishingLootSpawnEvent event) {
+
+        Player player = event.getPlayer();
+
+        if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld()))
+            return;
+
+        // check if in creative
+        if (!JobsPaymentListener.payIfCreative(player))
+            return;
+
+        if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getWorld().getName()))
+            return;
+
+        // check if player is riding
+        if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle() && !player.getVehicle().getType().equals(EntityType.BOAT))
+            return;
+
+        if (!JobsPaymentListener.payForItemDurabilityLoss(player))
+            return;
+
+        if (event.getLoot().type() != LootType.ITEM)
+            return;
+
+        // check is mcMMO enabled
+        if (JobsHook.mcMMO.isEnabled()) {
+            McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
+            // check is the fishing being exploited. If yes, prevent payment.
+            if (mcMMOPlayer != null && ExperienceConfig.getInstance().isFishingExploitingPrevented()
+                    && mcMMOPlayer.getFishingManager().isExploitingFishing(event.getLocation().toVector())) {
+                return;
+            }
+        }
+
+        Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new CustomFishingInfo(CustomFishingManager.getLastFishId(), ActionType.CUSTOMFISHING), event.getEntity());
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsDefaultFishPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsDefaultFishPaymentListener.java
@@ -1,0 +1,63 @@
+package com.gamingmesh.jobs.listeners;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.actions.ItemActionInfo;
+import com.gamingmesh.jobs.actions.PyroFishingProInfo;
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.hooks.JobsHook;
+import com.gamingmesh.jobs.hooks.pyroFishingPro.PyroFishingProManager;
+import com.gmail.nossr50.config.experience.ExperienceConfig;
+import com.gmail.nossr50.datatypes.player.McMMOPlayer;
+import com.gmail.nossr50.util.player.UserManager;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerFishEvent;
+
+public class JobsDefaultFishPaymentListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerFish(PlayerFishEvent event) {
+
+        Player player = event.getPlayer();
+
+        if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld()))
+            return;
+
+        // check if in creative
+        if (!JobsPaymentListener.payIfCreative(player))
+            return;
+
+        if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getWorld().getName()))
+            return;
+
+        // check if player is riding
+        if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle() && !player.getVehicle().getType().equals(EntityType.BOAT))
+            return;
+
+        if (!JobsPaymentListener.payForItemDurabilityLoss(player))
+            return;
+
+        if (event.getState() == PlayerFishEvent.State.CAUGHT_FISH && event.getCaught() instanceof Item) {
+            // check is mcMMO enabled
+            if (JobsHook.mcMMO.isEnabled()) {
+                McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
+                // check is the fishing being exploited. If yes, prevent payment.
+                if (mcMMOPlayer != null && ExperienceConfig.getInstance().isFishingExploitingPrevented()
+                        && mcMMOPlayer.getFishingManager().isExploitingFishing(event.getHook().getLocation().toVector())) {
+                    return;
+                }
+            }
+
+            if (JobsHook.PyroFishingPro.isEnabled() && PyroFishingProManager.getFish() != null) {
+                Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new PyroFishingProInfo(PyroFishingProManager.getFish(), ActionType.PYROFISHINGPRO), event.getCaught());
+                return;
+            }
+
+            Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new ItemActionInfo(((Item) event.getCaught()).getItemStack(), ActionType.FISH), event.getCaught());
+        }
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -547,48 +547,6 @@ public final class JobsPaymentListener implements Listener {
     }
 
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-    public void onPlayerFish(PlayerFishEvent event) {
-
-        Player player = event.getPlayer();
-
-        if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld()))
-            return;
-
-        // check if in creative
-        if (!payIfCreative(player))
-            return;
-
-        if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getWorld().getName()))
-            return;
-
-        // check if player is riding
-        if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle() && !player.getVehicle().getType().equals(EntityType.BOAT))
-            return;
-
-        if (!payForItemDurabilityLoss(player))
-            return;
-
-        if (event.getState() == PlayerFishEvent.State.CAUGHT_FISH && event.getCaught() instanceof Item) {
-            // check is mcMMO enabled
-            if (JobsHook.mcMMO.isEnabled()) {
-                McMMOPlayer mcMMOPlayer = UserManager.getPlayer(player);
-                // check is the fishing being exploited. If yes, prevent payment.
-                if (mcMMOPlayer != null && ExperienceConfig.getInstance().isFishingExploitingPrevented()
-                    && mcMMOPlayer.getFishingManager().isExploitingFishing(event.getHook().getLocation().toVector())) {
-                    return;
-                }
-            }
-
-            if (JobsHook.PyroFishingPro.isEnabled() && PyroFishingProManager.getFish() != null) {
-                Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new PyroFishingProInfo(PyroFishingProManager.getFish(), ActionType.PYROFISHINGPRO), event.getCaught());
-                return;
-            }
-
-            Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new ItemActionInfo(((Item) event.getCaught()).getItemStack(), ActionType.FISH), event.getCaught());
-        }
-    }
-
-    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onAnimalTame(EntityTameEvent event) {
         if (!Jobs.getGCManager().canPerformActionInWorld(event.getEntity().getWorld()))
             return;

--- a/src/main/resources/jobs/_EXAMPLE.yml
+++ b/src/main/resources/jobs/_EXAMPLE.yml
@@ -446,6 +446,12 @@ exampleJob:
       income: 1.0
       points: 1.0
       experience: 1.0
+  # Catching CUSTOM fish of the CustomFishing plugin
+  CustomFishing:
+    CustomFishId:
+      income: 1.0
+      points: 1.0
+      experience: 1.0
   # Repairing items
   Repair:
     wood_sword:

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ website: https://www.spigotmc.org/resources/4216/
 authors: [Zrips]
 contributors: [montlikadani]
 depend: [CMILib]
-softdepend: [Vault, Essentials, MythicMobs, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, StackMob, PyroFishingPro, BlockTracker]
+softdepend: [Vault, Essentials, MythicMobs, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, StackMob, PyroFishingPro, BlockTracker, CustomFishing]
 commands:
   jobs:
     description: Jobs


### PR DESCRIPTION
If CustomFishing plugin working with Jobs, "Fish" action is broke.
This is because CustomFishing's 'FishingLootSpawnEvent' cancels 'CAUGHT_FISH state of PlayerFishEvent', so even if CustomFishing existed at the same time, Jobs Fish action broken, so had to solve it. (then maybe PyroFishingPro action broken too, but does anyone use CF and PFP at the same time?)

I haven't figured out how to get Jobs' existing PlayerFishEvent and CustomFishing to work together.
It might be possible if I modify the code more and coordinate the EventPriority better, but I don't have that much free time, and I think this PR solved the minimum problem in supporting CustomFishing enough, so I just PR this.

In this PR, If you enable CustomFishing support in generalConfig.yml, disable the existing "Fish" and "PyroFishingPro" action and enable only "CustomFishing" action.