### PR TITLE
Introduced Config-Option To Disable Block-Ownership

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
 			<groupId>com.gmail.nossr50.mcMMO</groupId>
 			<artifactId>mcMMO</artifactId>
 			<version>2.2.004</version>
+			<exclusions>
+				<exclusion>
+					<artifactId>*</artifactId>
+					<groupId>com.sk89q.worldguard</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- Vault -->
 		<dependency>
@@ -68,7 +74,7 @@
 		<dependency>
 			<groupId>com.sk89q.worldguard</groupId>
 			<artifactId>worldguard-bukkit</artifactId>
-			<version>7.0.2-SNAPSHOT</version>
+			<version>7.0.12</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bukkit</artifactId>
@@ -96,7 +102,7 @@
 		<dependency>
 			<groupId>com.sk89q.worldedit</groupId>
 			<artifactId>worldedit-bukkit</artifactId>
-			<version>7.1.0-SNAPSHOT</version>
+			<version>7.3.10</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>bukkit-classloader-check</artifactId>
@@ -134,9 +140,9 @@
 		</dependency>
 		<!-- PlaceholderAPI -->
 		<dependency>
-			<groupId>me.clip</groupId>
+			<groupId>com.github.placeholderapi</groupId>
 			<artifactId>placeholderapi</artifactId>
-			<version>2.10.9</version>
+			<version>2.11.6</version>
 			<scope>provided</scope>
 			<exclusions>
 				<exclusion>
@@ -185,9 +191,9 @@
 			<systemPath>${basedir}/libs/PyroFishingPro-4.9.1.jar</systemPath>
 		</dependency>
 		<dependency>
-            <groupId>com.github.Xiao-MoMi</groupId>
-            <artifactId>Custom-Fishing</artifactId>
-            <version>2.2.34</version>
+            <groupId>net.momirealms</groupId>
+            <artifactId>custom-fishing</artifactId>
+            <version>2.3.4</version>
             <scope>provided</scope>
         </dependency>
 		<!-- CMILib -->
@@ -200,6 +206,10 @@
 		</dependency>
 	</dependencies>
 	<repositories>
+		<repository>
+			<id>momirealms</id>
+			<url>https://repo.momirealms.net/releases/</url>
+		</repository>
 		<repository>
 			<id>CodeMC</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -109,7 +109,7 @@ public class GeneralConfigManager {
         EmptyServerAccountActionBar, ShowTotalWorkers, ShowPenaltyBonus, useDynamicPayment,
         JobsGUIOpenOnBrowse, JobsGUIShowChatBrowse, JobsGUISwitcheButtons, ShowActionNames, hideItemAttributes,
         DisableJoiningJobThroughGui, FireworkLevelupUse, UseRandom, UsePerPermissionForLeaving,
-        EnableConfirmation, jobsInfoOpensBrowse, MonsterDamageUse, MonsterDamageIgnoreBosses, tameablesPayout, useMaxPaymentCurve, blockOwnershipTakeOver,
+        EnableConfirmation, jobsInfoOpensBrowse, MonsterDamageUse, MonsterDamageIgnoreBosses, tameablesPayout, useMaxPaymentCurve, blockOwnershipTakeOver, blockOwnershipDisabled,
         hideJobsInfoWithoutPermission, UseTaxes, TransferToServerAccount, TakeFromPlayersPayment, AutoJobJoinUse, AllowDelevel, RomanNumbers,
         BossBarEnabled = false, ActionBarEnabled, ExploreCompact, ExploreSaveIntoDatabase = false, DBCleaningJobsUse, DBCleaningUsersUse,
         DisabledWorldsUse, UseAsWhiteListWorldList, MythicMobsEnabled,
@@ -1216,6 +1216,9 @@ public class GeneralConfigManager {
         c.addComment("BlockOwnership.TakeOver", "When enabled by interacting with furncae ownership will get transfered to new player",
             "If set to false then furnace will belong to player who interacted with it first until its ownership is removed");
         blockOwnershipTakeOver = c.get("BlockOwnership.TakeOver", false);
+
+        c.addComment("BlockOwnership.Disabled", "When set to true, all checks and actions regarding ownership will no longer be carried out. This mode does not cause a loss of any already existing data.");
+        blockOwnershipDisabled = c.get("BlockOwnership.Disabled", false);
 
         c.save();
     }

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -385,6 +385,9 @@ public final class JobsPaymentListener implements Listener {
         if (!Jobs.getGCManager().canPerformActionInWorld(block.getWorld()))
             return;
 
+        if (Jobs.getGCManager().blockOwnershipDisabled)
+            return;
+
         BlockOwnerShip ownerShip = plugin.getBlockOwnerShip(CMIMaterial.get(block), false).orElse(null);
 
         if (ownerShip == null)
@@ -1118,6 +1121,9 @@ public final class JobsPaymentListener implements Listener {
     }
 
     private void processItemMove(Block block) {
+        if (Jobs.getGCManager().blockOwnershipDisabled)
+            return;
+
         plugin.getBlockOwnerShip(CMIMaterial.get(block)).ifPresent(os -> {
             if (!os.disable(block) || !Jobs.getGCManager().informOnPaymentDisable)
                 return;
@@ -1145,6 +1151,9 @@ public final class JobsPaymentListener implements Listener {
         Block block = event.getBlock();
 
         if (!Jobs.getGCManager().canPerformActionInWorld(block.getWorld()))
+            return;
+
+        if (Jobs.getGCManager().blockOwnershipDisabled)
             return;
 
         BlockOwnerShip bos = plugin.getBlockOwnerShip(CMIMaterial.get(block), false).orElse(null);
@@ -1773,6 +1782,8 @@ public final class JobsPaymentListener implements Listener {
         boolean isFurnace = cmat == CMIMaterial.FURNACE || cmat == CMIMaterial.LEGACY_BURNING_FURNACE;
 
         if ((isFurnace || cmat == CMIMaterial.SMOKER || cmat == CMIMaterial.BLAST_FURNACE || isBrewingStand)) {
+            if (Jobs.getGCManager().blockOwnershipDisabled)
+                return;
 
             BlockOwnerShip blockOwner = plugin.getBlockOwnerShip(cmat).orElse(null);
             if (blockOwner == null) {


### PR DESCRIPTION
Hey there!

Our server would like to completely disable the block-ownership feature, including all messages as well as checks and actions. I believe that my changes represent a simple and non-invasive way to do so, defaulting to false, as to not change behavior for anybody else.

I'm looking forward to hearing back from you and hope that we can add this option to the main repo.

Best Regards,
BlvckBytes