### PR TITLE
Added rewards via Vault for quests

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/editquests.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/editquests.java
@@ -258,6 +258,8 @@ public class editquests implements Cmd {
             }
         }
 
+        cfg.set(path + "RewardAmount", quest.getRewardAmount() > 0 ? quest.getRewardAmount() : null);
+
         cfg.set(path + "RewardCommands", quest.getRewardCmds().isEmpty() ? null : quest.getRewardCmds());
         cfg.set(path + "RewardDesc", quest.getDescription().isEmpty() ? null : quest.getDescription());
         cfg.set(path + "RestrictedAreas", quest.getRestrictedAreas().isEmpty() ? null : quest.getRestrictedAreas());
@@ -466,6 +468,36 @@ public class editquests implements Cmd {
                         }
                         chance = CMINumber.clamp(chance, 0, 100);
                         quest.setChance(chance);
+                        updateQuestInFile(sender, quest);
+                    }
+
+                    @Override
+                    public void onDisable() {
+                        mainWindow(sender, quest);
+                    }
+                };
+                chatEdit.setCheckForCancel(true);
+                chatEdit.printMessage();
+            }
+        };
+        rm.addCommand(rmc);
+
+        rm.addText(Jobs.getLanguage().getMessage("command.editquests.help.output.rewardAmount") + quest.getRewardAmount());
+        rm.addHover(LC.modify_editSymbolHover.getLocale("[text]", quest.getRewardAmount()));
+        rmc = new RawMessageCommand() {
+            @Override
+            public void run(CommandSender sender) {
+                ChatMessageEdit chatEdit = new ChatMessageEdit(sender, quest.getQuestName()) {
+                    @Override
+                    public void run(String message) {
+                        int rewardAmount = 0;
+                        try {
+                            rewardAmount = Integer.parseInt(message);
+                        } catch (Throwable e) {
+                            LC.info_UseInteger.sendMessage(sender);
+                            return;
+                        }
+                        quest.setRewardAmount(rewardAmount);
                         updateQuestInFile(sender, quest);
                     }
 

--- a/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ConfigManager.java
@@ -227,6 +227,9 @@ public class ConfigManager {
             "Use [playerName] to insert players name who finished that quest");
         cfg.get(questPt + ".RewardCommands", Arrays.asList("money give [playerName] 500", "msg [playerName] Completed quest!"));
 
+        cfg.addComment(questPt + ".RewardAmount", "Reward amount to be given to player after quest is finished");
+        cfg.get(questPt + ".RewardAmount", 0);
+
         cfg.addComment(questPt + ".RewardDesc", "Quest description to be used to explain quest requirements or rewards for player");
         cfg.get(questPt + ".RewardDesc", Arrays.asList("Break 300 Oak wood", "Get 500 bucks for this"));
 
@@ -1490,6 +1493,7 @@ public class ConfigManager {
                             quest.setMaxLvl(sqsection.getInt("toLevel"));
 
                         quest.setChance(sqsection.getInt("Chance", 100));
+                        quest.setRewardAmount(sqsection.getDouble("RewardAmount"));
                         quest.setRewardCmds(sqsection.getStringList("RewardCommands"));
                         quest.setDescription(sqsection.getStringList("RewardDesc"));
                         quest.setRestrictedArea(sqsection.getStringList("RestrictedAreas"));

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -264,6 +264,7 @@ public class LanguageManager {
             c.get("command.editquests.help.output.to", " &eto: &f");
             c.get("command.editquests.help.output.objectives", "Objectives");
             c.get("command.editquests.help.output.rewards", "Reward commands");
+            c.get("command.editquests.help.output.rewardAmount", " &eAmount: &f");
             c.get("command.editquests.help.output.description", "&eDescription");
             c.get("command.editquests.help.output.areas", "&eRestricted areas");
 

--- a/src/main/java/com/gamingmesh/jobs/container/Quest.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Quest.java
@@ -25,6 +25,8 @@ public class Quest {
 
     private final List<String> rewardCmds = new ArrayList<>(), rewards = new ArrayList<>(), area = new ArrayList<>();
 
+    private double rewardAmount = 0;
+
     private boolean stopped = false;
 
     private Map<ActionType, Map<String, QuestObjective>> objectives = new HashMap<>();
@@ -54,6 +56,11 @@ public class Quest {
             this.rewardCmds.addAll(rewardCmds);
         }
     }
+
+    public double getRewardAmount() { return rewardAmount; }
+
+    public void setRewardAmount(double rewardAmount) { this.rewardAmount = rewardAmount; }
+
 
     public List<String> getDescription() {
         return rewards;

--- a/src/main/java/com/gamingmesh/jobs/container/QuestProgression.java
+++ b/src/main/java/com/gamingmesh/jobs/container/QuestProgression.java
@@ -183,6 +183,10 @@ public class QuestProgression {
 
         jPlayer.addDoneQuest(questJob);
 
+        if (quest.getRewardAmount() > 0) {
+            Jobs.getEconomy().getEconomy().depositPlayer(player, quest.getRewardAmount());
+        }
+
         for (String one : quest.getRewardCmds()) {
             ServerCommandEvent ev = new ServerCommandEvent(Bukkit.getConsoleSender(), one.replace("[playerName]", player.getName()));
             Bukkit.getPluginManager().callEvent(ev);


### PR DESCRIPTION
Hello!
In order to make Jobs configurations more easily compatible with multiple servers, giving money without using a command, which is limited to the syntax of the plugin used, is much better through Vault.
I have therefore added a new option, RewardAmount, which allows giving money to a player who completes a quest.

Théo