### PR TITLE
fixed `/jobs top <job>` having a null progression (skip them)

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -399,7 +399,7 @@ public class PlayerManager {
      * This can return null sometimes if the given player
      * is not cached into memory.
      *
-     * @param player the player uuid
+     * @param uuid the player uuid
      * @return {@link JobsPlayer} the player job info of the player
      */
     public JobsPlayer getJobsPlayer(UUID uuid) {
@@ -413,7 +413,7 @@ public class PlayerManager {
      * This can return null sometimes if the given player
      * is not cached into memory.
      *
-     * @param player name - the player name who's job you're getting
+     * @param playerName name - the player name who's job you're getting
      * @return {@link JobsPlayer} the player job info of the player
      */
     public JobsPlayer getJobsPlayer(String playerName) {

--- a/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
@@ -344,7 +344,7 @@ public class JobsCommands implements CommandExecutor {
     /**
      * Displays info about a particular action
      * @param player - the player of the job
-     * @param prog - the job we are displaying info about
+     * @param job - the job we are displaying info about
      * @param type - the type of action
      * @return the message
      */
@@ -485,7 +485,8 @@ public class JobsCommands implements CommandExecutor {
 
     /**
      * Displays job stats about a particular player's job from archive
-     * @param jobInfo - jobinfo string line
+     * @param jPlayer - the player of the job
+     * @param jobProg - the job progress of the players job
      * @return the message
      */
     public String jobStatsMessageArchive(JobsPlayer jPlayer, JobProgression jobProg) {

--- a/src/main/java/com/gamingmesh/jobs/commands/list/top.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/top.java
@@ -102,7 +102,7 @@ public class top implements Cmd {
                 continue;
 
             JobProgression progression = jPlayer.getJobProgression(job);
-
+            if(progression == null) continue; // Skip if the UUID has no progression in this job
             if (Jobs.getGCManager().ShowToplistInScoreboard && sender instanceof Player)
                 ls.add(Jobs.getLanguage().getMessage("scoreboard.line",
                     "%number%", pi.getPositionForOutput(i),


### PR DESCRIPTION
Fixes progression errors when a progression is null.