### PR TITLE
Resolve block update exception overload and block concurrency issues

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/ExploitProtectionManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/ExploitProtectionManager.java
@@ -1,7 +1,8 @@
 package com.gamingmesh.jobs.config;
 
-import java.util.HashMap;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 
 import org.bukkit.Chunk;
 import org.bukkit.Location;
@@ -20,7 +21,6 @@ import net.Zrips.CMILib.ActionBar.CMIActionBar;
 import net.Zrips.CMILib.Container.CMIBlock;
 import net.Zrips.CMILib.Container.CMIBlock.Bisect;
 import net.Zrips.CMILib.Items.CMIMaterial;
-import net.Zrips.CMILib.Logs.CMIDebug;
 import net.Zrips.CMILib.PersistentData.CMIChunkPersistentDataContainer;
 
 public class ExploitProtectionManager {
@@ -29,7 +29,7 @@ public class ExploitProtectionManager {
     private static final String NAMETIME = "Time";
     private static final String NAMEPAID = "Paid";
 
-    private HashMap<String, HashMap<String, chunkData>> map = new HashMap<>();
+    private final ConcurrentMap<String, ConcurrentMap<String, chunkData>> map = new ConcurrentHashMap<>();
 
     class chunkData {
         private CMIChunkPersistentDataContainer container;
@@ -69,14 +69,15 @@ public class ExploitProtectionManager {
     private chunkData getChunkData(Chunk chunk) {
         if (chunk == null)
             return null;
-        HashMap<String, chunkData> world = map.computeIfAbsent(chunk.getWorld().getName(), x -> new HashMap<>());
-        return world.computeIfAbsent(chunk.getX() + ":" + chunk.getZ(), x -> new chunkData(new CMIChunkPersistentDataContainer(NAMEGENERAL, chunk)));
+        ConcurrentMap<String, chunkData> world = map.computeIfAbsent(chunk.getWorld().getName(), w -> new ConcurrentHashMap<>());
+        String key = chunk.getX() + ":" + chunk.getZ();
+        return world.computeIfAbsent(key, k -> new chunkData(new CMIChunkPersistentDataContainer(NAMEGENERAL, chunk)));
     }
 
     public void removePDC(Chunk chunk) {
         if (!Jobs.getGCManager().useNewBlockProtection)
             return;
-        HashMap<String, chunkData> world = map.get(chunk.getWorld().getName());
+        ConcurrentMap<String, chunkData> world = map.get(chunk.getWorld().getName());
         if (world == null)
             return;
 
@@ -192,7 +193,7 @@ public class ExploitProtectionManager {
             } else {
                 block = block.getLocation().clone().add(0, -1, 0).getBlock();
             }
-            return;
+            break;
         }
 
         CMIChunkPersistentDataContainer pdc = getPDC(block);

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -757,7 +757,7 @@ public final class JobsPaymentListener implements Listener {
                 preInv[i] = preInv[i].clone();
         }
 
-        CMIScheduler.runTaskLater(Jobs.getInstance(), () -> {
+        CMIScheduler.runAtEntityLater(Jobs.getInstance(), player, () -> {
             final ItemStack[] postInv = player.getInventory().getContents();
             int newItemsCount = 0;
 
@@ -1823,10 +1823,15 @@ public final class JobsPaymentListener implements Listener {
 
             String type = block.getType().toString();
 
+            final Location blockLocation = block.getLocation();
+
             if ((Version.isCurrentEqualOrHigher(Version.v1_13_R1) && (type.endsWith("_LOG") || type.endsWith("_WOOD"))) ||
                 (Version.isCurrentEqualOrHigher(Version.v1_16_R1) && (type.endsWith("_STEM") || type.endsWith("_HYPHAE"))) ||
                 (Version.isCurrentEqualOrHigher(Version.v1_20_R1) && (type.equalsIgnoreCase("BAMBOO_BLOCK")))) {
-                CMIScheduler.runTaskLater(plugin, () -> Jobs.action(jPlayer, new BlockActionInfo(block, ActionType.STRIPLOGS), block), 1);
+                CMIScheduler.runAtLocationLater(plugin, blockLocation, () -> {
+                    Block b = blockLocation.getBlock();
+                    Jobs.action(jPlayer, new BlockActionInfo(b, ActionType.STRIPLOGS), b);
+                }, 1);
             }
         }
     }


### PR DESCRIPTION
This resolves some obscure concurrency issues with Folia. I've only managed to identify two whilst running on a 200-300 player instances. I'm fairly confident these patches are sufficient; however, I could be wrong.