### PR TITLE
Fix java version incompatibility and NoSuchMethodError in versions older than 1.20.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
 	<url>http://maven.apache.org</url>
 
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/src/main/java/com/gamingmesh/jobs/container/JobsMobSpawner.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsMobSpawner.java
@@ -1,5 +1,7 @@
 package com.gamingmesh.jobs.container;
 
+import net.Zrips.CMILib.CMILib;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.metadata.FixedMetadataValue;
 
@@ -49,7 +51,7 @@ public class JobsMobSpawner {
 
     public static boolean isSpawnerEntity(Entity entity) {
         if (Version.isCurrentEqualOrHigher(Version.v1_15_R1)) {
-            return CMIPersistentDataContainer.get(entity).hasKey(getMobSpawnerMetadata());
+            return CMIPersistentDataContainer.get(entity).getKeys().contains(new NamespacedKey(CMILib.getInstance(), getMobSpawnerMetadata()));
         }
         return entity.hasMetadata(getMobSpawnerMetadata());
     }
@@ -64,7 +66,8 @@ public class JobsMobSpawner {
 
     public static void setSpawnerMeta(Entity entity) {
         if (Version.isCurrentEqualOrHigher(Version.v1_15_R1)) {
-            CMIPersistentDataContainer.get(entity).set(getMobSpawnerMetadata(), true);
+            byte bool = 1;
+            CMIPersistentDataContainer.get(entity).set(getMobSpawnerMetadata(), bool);
         } else {
             entity.setMetadata(getMobSpawnerMetadata(), new FixedMetadataValue(Jobs.getInstance(), true));
         }


### PR DESCRIPTION
The JobsMobSpawner class was using methods from CMILib whose implementation doesn't exist in 1.17.1, more specifically the BOOLEAN PDT (was added in 1.19.4) and the PersistentDataContainer#has(NamespacedKey) method without a PDT (was added in 1.20.4). Also more importantly, Jobs target version was made to be java 21 which makes the plugin unable to load properly on 1.17.1 (or any version older than 1.20) so I took the liberty to change the target again (compiles and runs fine as per my tests).

If this was on purpose, then I am fine to maintain my own fork however since the Jobs supported versions range from 1.8 to latest, I assumed this wasn't on purpose.