### PR TITLE
Add functionality to rest

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/BoostManager.java
+++ b/src/main/java/com/gamingmesh/jobs/BoostManager.java
@@ -158,27 +158,4 @@ public final class BoostManager {
 
         saveBoosts();
     }
-
-    public static void clearJobBoosts(Job job) {
-        if (job == null)
-            return;
-
-        for (CurrencyType type : CurrencyType.values()) {
-            job.addBoost(type, 0);
-        }
-
-        if (Jobs.getGCManager().isBoostPersistenceEnabled())
-            saveBoosts();
-    }
-
-    public static void clearAllBoosts() {
-        for (Job job : Jobs.getJobs()) {
-            for (CurrencyType type : CurrencyType.values()) {
-                job.addBoost(type, 0);
-            }
-        }
-
-        if (Jobs.getGCManager().isBoostPersistenceEnabled())
-            saveBoosts();
-    }
 }

--- a/src/main/java/com/gamingmesh/jobs/BoostManager.java
+++ b/src/main/java/com/gamingmesh/jobs/BoostManager.java
@@ -1,0 +1,184 @@
+/**
+ * Jobs Plugin for Bukkit
+ * Copyright (C) 2011 Zak Ford <zak.j.ford@gmail.com>
+ * 
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package com.gamingmesh.jobs;
+
+import java.io.File;
+import java.util.Set;
+
+import com.gamingmesh.jobs.container.BoostMultiplier;
+import com.gamingmesh.jobs.container.CurrencyType;
+import com.gamingmesh.jobs.container.Job;
+
+import net.Zrips.CMILib.FileHandler.ConfigReader;
+import net.Zrips.CMILib.Messages.CMIMessages;
+
+public final class BoostManager {
+
+    private static final String boostFile = "activeBoosts.yml";
+
+    private BoostManager() {
+    }
+
+    public static void saveBoosts() {
+        if (!Jobs.getGCManager().isBoostPersistenceEnabled())
+            return;
+
+        ConfigReader cfg;
+        try {
+            cfg = new ConfigReader(Jobs.getInstance(), boostFile);
+        } catch (Exception e) {
+            Jobs.getPluginLogger().severe("Failed to create boost config: " + e.getMessage());
+            e.printStackTrace();
+            return;
+        }
+
+        // Clear existing data
+        cfg.getC().getKeys(false).forEach(key -> cfg.getC().set(key, null));
+
+        int savedBoosts = 0;
+        for (Job job : Jobs.getJobs()) {
+            BoostMultiplier boost = job.getBoost();
+            if (boost == null)
+                continue;
+
+            for (CurrencyType type : CurrencyType.values()) {
+                double amount = boost.get(type);
+                Long time = boost.getTime(type);
+
+                // Only save active boosts (non-zero amount or with time)
+                if (amount != 0 || time != null) {
+                    String path = job.getName() + "." + type.toString().toLowerCase();
+                    cfg.set(path + ".amount", amount);
+                    if (time != null) {
+                        cfg.set(path + ".expireTime", time);
+                    }
+                    savedBoosts++;
+                }
+            }
+        }
+
+        try {
+            cfg.save();
+            if (savedBoosts > 0) {
+                CMIMessages.consoleMessage("&e[Jobs] Saved " + savedBoosts + " active boosts");
+            }
+        } catch (Exception e) {
+            Jobs.getPluginLogger().severe("Failed to save boosts: " + e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    public static void loadBoosts() {
+        if (!Jobs.getGCManager().isBoostPersistenceEnabled())
+            return;
+
+        File file = new File(Jobs.getInstance().getDataFolder(), boostFile);
+        if (!file.exists())
+            return; // No boosts file exists yet
+
+        ConfigReader cfg;
+        try {
+            cfg = new ConfigReader(Jobs.getInstance(), boostFile);
+        } catch (Exception e) {
+            Jobs.getPluginLogger().severe("Failed to load boost config: " + e.getMessage());
+            e.printStackTrace();
+            return;
+        }
+
+        int loadedBoosts = 0;
+        int expiredBoosts = 0;
+
+        Set<String> jobNames = cfg.getC().getKeys(false);
+        for (String jobName : jobNames) {
+            Job job = Jobs.getJob(jobName);
+            if (job == null) {
+                Jobs.getPluginLogger().warning("Job '" + jobName + "' not found, skipping boosts");
+                continue;
+            }
+
+            Set<String> currencies = cfg.getC().getConfigurationSection(jobName).getKeys(false);
+            for (String currencyName : currencies) {
+                CurrencyType type = CurrencyType.getByName(currencyName);
+                if (type == null) {
+                    Jobs.getPluginLogger().warning("Unknown currency type '" + currencyName + "', skipping");
+                    continue;
+                }
+
+                String basePath = jobName + "." + currencyName;
+                double amount = cfg.get(basePath + ".amount", 0.0);
+                Long expireTime = cfg.getC().isLong(basePath + ".expireTime")
+                        ? cfg.getC().getLong(basePath + ".expireTime")
+                        : null;
+
+                // Check if boost has expired
+                if (expireTime != null && expireTime < System.currentTimeMillis()) {
+                    expiredBoosts++;
+                    continue; // Skip expired boosts
+                }
+
+                // Apply the boost
+                if (expireTime != null) {
+                    job.addBoost(type, amount, (expireTime - System.currentTimeMillis()) / 1000L);
+                } else {
+                    job.addBoost(type, amount);
+                }
+                loadedBoosts++;
+            }
+        }
+
+        if (loadedBoosts > 0 || expiredBoosts > 0) {
+            CMIMessages.consoleMessage("&e[Jobs] Loaded " + loadedBoosts + " active boosts" +
+                    (expiredBoosts > 0 ? " (skipped " + expiredBoosts + " expired)" : ""));
+        }
+
+        // Clean up expired boosts by saving again
+        if (expiredBoosts > 0)
+            saveBoosts();
+    }
+
+    public static void onBoostAdded() {
+        if (!Jobs.getGCManager().isBoostPersistenceEnabled())
+            return;
+
+        saveBoosts();
+    }
+
+    public static void clearJobBoosts(Job job) {
+        if (job == null)
+            return;
+
+        for (CurrencyType type : CurrencyType.values()) {
+            job.addBoost(type, 0);
+        }
+
+        if (Jobs.getGCManager().isBoostPersistenceEnabled())
+            saveBoosts();
+    }
+
+    public static void clearAllBoosts() {
+        for (Job job : Jobs.getJobs()) {
+            for (CurrencyType type : CurrencyType.values()) {
+                job.addBoost(type, 0);
+            }
+        }
+
+        if (Jobs.getGCManager().isBoostPersistenceEnabled())
+            saveBoosts();
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -941,6 +941,13 @@ public final class Jobs extends JavaPlugin {
 
         dao.loadPlayerData();
 
+        // Load active boosts from file
+        try {
+            BoostManager.loadBoosts();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
+
         // Schedule
         if (getGCManager().enableSchedule) {
             try {
@@ -961,6 +968,13 @@ public final class Jobs extends JavaPlugin {
 
         if (dao != null && Jobs.getGeneralConfigManager().ExploreSaveIntoDatabase)
             dao.saveExplore();
+
+        // Save active boosts before shutdown
+        try {
+            BoostManager.saveBoosts();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
 
         BlockOwnerShip.save(blockOwnerShipsMaterial);
 

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -121,7 +121,7 @@ public class GeneralConfigManager {
         BossBarEnabled = false, ActionBarEnabled, ExploreCompact, ExploreSaveIntoDatabase = false, DBCleaningJobsUse, DBCleaningUsersUse,
         DisabledWorldsUse, UseAsWhiteListWorldList, MythicMobsEnabled,
         LoggingUse, payForCombiningItems, payForStackedEntities, payForAbove = false,
-        payForEachVTradeItem, allowEnchantingBoostedItems, preventShopItemEnchanting, useCustomFishingOnly = false;
+        payForEachVTradeItem, allowEnchantingBoostedItems, preventShopItemEnchanting, useCustomFishingOnly = false, boostPersistenceEnabled = true;
     public MessageToggleState BossBarsMessageDefault = MessageToggleState.Rapid;
     public MessageToggleState ActionBarsMessageDefault = MessageToggleState.Rapid;
     public MessageToggleState ChatTextMessageDefault = MessageToggleState.Batched;
@@ -250,6 +250,10 @@ public class GeneralConfigManager {
         return saveOnDisconnect;
     }
 
+    public boolean isBoostPersistenceEnabled() {
+        return boostPersistenceEnabled;
+    }
+
     public boolean MultiServerCompatability() {
         return MultiServerCompatability;
     }
@@ -367,6 +371,12 @@ public class GeneralConfigManager {
             "Player data is always periodically auto-saved and autosaved during a clean shutdown.",
             "Only enable this if you have a multi-server setup, or have a really good reason for enabling this.", "Turning this on will decrease database performance.");
         saveOnDisconnect = c.get("save-on-disconnect", false);
+
+        c.addComment("boost-persistence", "Should job boosts persist across server restarts?",
+            "When enabled, boosts applied via /jobs boost command will be saved and restored after server restart.",
+            "This ensures that timed boosts continue for their full duration even if the server restarts.",
+            "Set to false if this feature causes issues with your server setup.");
+        boostPersistenceEnabled = c.get("boost-persistence", true);
 
         c.addComment("selectionTool", "Tool used when selecting bounds for restricted area.");
         getSelectionTool = c.get("selectionTool", "golden_hoe");

--- a/src/main/java/com/gamingmesh/jobs/container/Job.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Job.java
@@ -45,6 +45,7 @@ import com.gamingmesh.jobs.actions.EnchantActionInfo;
 import com.gamingmesh.jobs.actions.PotionItemActionInfo;
 import com.gamingmesh.jobs.container.JobsTop.topStats;
 import com.gamingmesh.jobs.stuff.Util;
+import com.gamingmesh.jobs.BoostManager;
 
 import net.Zrips.CMILib.Colors.CMIChatColor;
 import net.Zrips.CMILib.Container.CMINumber;
@@ -115,8 +116,8 @@ public class Job {
         int vipmaxLevel, Integer maxSlots, List<JobPermission> jobPermissions, List<JobCommands> jobCommands, List<JobConditions> jobConditions, Map<String, JobItems> jobItems,
         Map<String, JobLimitedItems> jobLimitedItems, List<String> cmdOnJoin, List<String> cmdOnLeave, ItemStack guiItem, int guiSlot, String bossbar, Long rejoinCD, List<String> worldBlacklist) {
         this(jobName, jobDisplayName, fullName, jobShortName, jobColour, maxExpEquation, displayMethod, maxLevel,
-            vipmaxLevel, maxSlots, jobPermissions, jobCommands, jobConditions,
-            jobLimitedItems, cmdOnJoin, cmdOnLeave, guiItem, guiSlot, worldBlacklist);
+                vipmaxLevel, maxSlots, jobPermissions, jobCommands, jobConditions,
+                jobLimitedItems, cmdOnJoin, cmdOnLeave, guiItem, guiSlot, worldBlacklist);
 
 //        this.jobItems = jobItems;
         this.description = description;
@@ -159,6 +160,12 @@ public class Job {
      */
     public void addBoost(CurrencyType type, double point) {
         boost.add(type, point);
+        // Notify boost manager to save the updated boosts
+        try {
+            BoostManager.onBoostAdded();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     /**
@@ -181,6 +188,12 @@ public class Job {
         }
 
         boost.add(type, point, System.currentTimeMillis() + (duration * 1000L));
+        // Notify boost manager to save the updated boosts
+        try {
+            BoostManager.onBoostAdded();
+        } catch (Throwable e) {
+            e.printStackTrace();
+        }
     }
 
     public void setBoost(BoostMultiplier boost) {
@@ -199,7 +212,7 @@ public class Job {
      */
     public boolean isSame(Job job) {
         return job != null && (id == job.getId() || jobName.equalsIgnoreCase(job.getName())
-            || fullName.equalsIgnoreCase(job.getJobFullName()) || fullName.equalsIgnoreCase(job.getName()));
+                || fullName.equalsIgnoreCase(job.getJobFullName()) || fullName.equalsIgnoreCase(job.getName()));
     }
 
     /**
@@ -342,8 +355,8 @@ public class Job {
             }
 
             return jobInfo.getName().equalsIgnoreCase(action.getNameWithSub()) ||
-                (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
-                jobInfo.getName().equalsIgnoreCase(action.getName());
+                    (jobInfo.getName() + ":" + jobInfo.getMeta()).equalsIgnoreCase(action.getNameWithSub()) ||
+                    jobInfo.getName().equalsIgnoreCase(action.getName());
         };
 
         String shortActionName = CMIMaterial.getGeneralMaterialName(action.getName());
@@ -718,7 +731,7 @@ public class Job {
             int target = new Random(System.nanoTime()).nextInt(100);
             for (Quest one : ls) {
                 if (one.isEnabled() && one.getChance() >= target && (excludeQuests == null || !excludeQuests.contains(one.getConfigName().toLowerCase()))
-                    && one.isInLevelRange(level)) {
+                        && one.isInLevelRange(level)) {
                     return one;
                 }
             }


### PR DESCRIPTION
Introduces persistent storage for job boosts, ensuring that boosts applied via commands are saved to disk and restored after a server restart. The main changes include a new `BoostManager` class to handle saving and loading boosts, integration of boost persistence into the plugin's startup and shutdown lifecycle, and configuration options for enabling or disabling this feature.

**Boost persistence feature:**

* Added new `BoostManager` class (`BoostManager.java`) to handle saving active boosts to `activeBoosts.yml` and loading them on server startup. It manages both timed and permanent boosts, skips expired boosts, and cleans up expired entries.
* Integrated boost persistence into the plugin lifecycle: boosts are loaded during startup (`Jobs.reload`) and saved during shutdown (`Jobs.onDisable`). 
* Boosts are now saved automatically whenever a boost is added to a job, ensuring up-to-date persistence. This is triggered in the `Job.addBoost` methods. 

**Configuration and settings:**

* Added a new config setting `boost-persistence` (default: true) to `GeneralConfigManager`, allowing server owners to enable or disable boost persistence. This is documented with comments in the config loader.
* Provided a getter method `isBoostPersistenceEnabled()` in `GeneralConfigManager` for use throughout the codebase.

Closes #1344 