### PR TITLE
fix(mcmmo): mcMMO multipliers being overridden by other boosts

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -525,7 +525,7 @@ public class GeneralConfigManager {
 				"Tool and weapon items will be ignored if those are equiped in players armor slots", "None tool or weapon items will be allowed in players head slot");
 		boostedItemsSlotSpecific = c.get("boosted-items-slot-specific", true);
 
-		c.addComment("multiply-boosted-extra-values", "Extra boost values for nearSpawner and petPay will be multiplied by sum of other boost values",
+		c.addComment("multiply-boosted-extra-values", "Extra boost values for nearSpawner, petPay, and mcMMO will be multiplied by sum of other boost values",
 				"When set to true and for example nearSpawner set to -0.98 aka 2% of original payment with other bonuses which should double payment will result in you getting 4% instead of corrent 102% payment",
 				"If set to false all bonus are sumed to one");
 		multiplyBoostedExtraValues = c.get("multiply-boosted-extra-values", false);

--- a/src/main/java/com/gamingmesh/jobs/container/Boost.java
+++ b/src/main/java/com/gamingmesh/jobs/container/Boost.java
@@ -63,7 +63,7 @@ public class Boost {
             if (bm == null)
                 continue;
 
-            if (one == BoostOf.NearSpawner || one == BoostOf.PetPay)
+            if (one == BoostOf.NearSpawner || one == BoostOf.PetPay || one == BoostOf.McMMO)
                 continue;
 
             if (bm.isValid(type)) {
@@ -84,12 +84,22 @@ public class Boost {
                     r = (r + 1) * (bm.get(type) + 1);
                     r -= 1;
                 }
+
+                bm = map.get(BoostOf.McMMO);
+                if (bm != null && bm.isValid(type) && bm.get(type) != 0) {
+                    r = (r + 1) * (bm.get(type) + 1);
+                    r -= 1;
+                }
             } else {
                 BoostMultiplier bm = map.get(BoostOf.NearSpawner);
                 if (bm != null && bm.isValid(type)) {
                     r += bm.get(type);
                 }
                 bm = map.get(BoostOf.PetPay);
+                if (bm != null && bm.isValid(type)) {
+                    r += bm.get(type);
+                }
+                bm = map.get(BoostOf.McMMO);
                 if (bm != null && bm.isValid(type)) {
                     r += bm.get(type);
                 }


### PR DESCRIPTION
mcMMO's multiplier is currently being overridden by other types of boosts