### PR TITLE
Add command to delete a user from the database

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -564,6 +564,17 @@ public class PlayerManager {
 
         Jobs.getJobsDAO().recordToArchive(jPlayer, job);
 
+        return cleanupLeavingJob(jPlayer, job);
+    }
+
+    /**
+     * Does the needed cleanup for player to leave the given job.
+     *
+     * @param jPlayer {@link JobsPlayer}
+     * @param job {@link Job}
+     */
+    private boolean cleanupLeavingJob(JobsPlayer jPlayer, Job job) {
+
         // let the user leave the job
         if (!jPlayer.leaveJob(job))
             return false;
@@ -614,26 +625,7 @@ public class PlayerManager {
         if (jobsLeaveEvent.isCancelled())
             return false;
 
-        // let the user leave the job
-        if (!jPlayer.leaveJob(job))
-            return false;
-
-        if (!Jobs.getJobsDAO().quitJob(jPlayer, job))
-            return false;
-
-        performCommandsOnLeave(jPlayer, job);
-        Jobs.leaveSlot(job);
-
-        jPlayer.getLeftTimes().remove(jPlayer.getUniqueId());
-
-        Jobs.getSignUtil().updateAllSign(job);
-
-        job.modifyTotalPlayerWorking(-1);
-
-        // Removing from cached item boost for recalculation
-        cache.remove(jPlayer.getUniqueId());
-
-        return true;
+        return cleanupLeavingJob(jPlayer, job);
     }
 
     /**
@@ -969,7 +961,7 @@ public class PlayerManager {
      * Performs command on level up
      *
      * @param jPlayer {@link JobsPlayer}
-     * @param job {@link Job}
+     * @param prog {@link JobProgression}
      * @param oldLevel
      */
     public void performCommandOnLevelUp(JobsPlayer jPlayer, JobProgression prog, int oldLevel) {
@@ -1001,7 +993,7 @@ public class PlayerManager {
      * Performs command for each level
      *
      * @param jPlayer {@link JobsPlayer}
-     * @param job {@link Job}
+     * @param prog {@link JobProgression}
      * @param oldLevel
      */
     public void performCommandOnLevelUp(JobsPlayer jPlayer, JobProgression prog, int oldLevel, int untilLevel) {
@@ -1016,7 +1008,7 @@ public class PlayerManager {
     /**
      * Checks whenever the given jobs player is under the max allowed jobs.
      *
-     * @param player {@link JobsPlayer}
+     * @param jPlayer {@link JobsPlayer}
      * @param currentCount the current jobs size
      * @return true if the player is under the given jobs size
      */

--- a/src/main/java/com/gamingmesh/jobs/actions/CustomKillInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/CustomKillInfo.java
@@ -31,7 +31,7 @@ public class CustomKillInfo extends BaseActionInfo {
 
     @Override
     public String getName() {
-	return name;
+	    return name;
     }
 
     @Override

--- a/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
@@ -1,5 +1,6 @@
 package com.gamingmesh.jobs.commands.list;
 
+import com.gamingmesh.jobs.PlayerManager;
 import com.gamingmesh.jobs.dao.JobsDAO;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -20,7 +21,8 @@ public class deluser implements Cmd {
             return false;
         }
 
-        JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(args[0]);
+        PlayerManager playerManager = Jobs.getPlayerManager();
+        JobsPlayer jPlayer = playerManager.getJobsPlayer(args[0]);
         if (jPlayer == null) {
             Language.sendMessage(sender, "general.error.noinfoByPlayer", "%playername%", args[0]);
             return true;
@@ -31,6 +33,11 @@ public class deluser implements Cmd {
             if (player != null) {
                 Language.sendMessage(sender, "command.deluser.output.target");
             }
+
+            // remove player job data
+            playerManager.deleteAllJobs(jPlayer);
+
+            // remove player from user DB
             Jobs.getJobsDAO().delUser(jPlayer.playerUUID);
 
             Language.sendMessage(sender, "general.admin.success");

--- a/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
@@ -1,0 +1,44 @@
+package com.gamingmesh.jobs.commands.list;
+
+import com.gamingmesh.jobs.dao.JobsDAO;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.commands.Cmd;
+import com.gamingmesh.jobs.container.Job;
+import com.gamingmesh.jobs.container.JobsPlayer;
+import com.gamingmesh.jobs.i18n.Language;
+
+import net.Zrips.CMILib.Colors.CMIChatColor;
+
+public class demote implements Cmd {
+
+    @Override
+    public Boolean perform(Jobs plugin, CommandSender sender, String[] args) {
+        if (args.length < 1) {
+            return false;
+        }
+
+        JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(args[0]);
+        if (jPlayer == null) {
+            Language.sendMessage(sender, "general.error.noinfoByPlayer", "%playername%", args[0]);
+            return true;
+        }
+
+        try {
+            Player player = jPlayer.getPlayer();
+            if (player != null) {
+                Language.sendMessage(sender, "command.deluser.output.target");
+            }
+            Jobs.getJobsDAO().delUser(jPlayer.playerUUID);
+
+            Language.sendMessage(sender, "general.admin.success");
+
+        } catch (Throwable e) {
+            Language.sendMessage(sender, "general.admin.error");
+        }
+        return true;
+    }
+}
+

--- a/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
@@ -12,7 +12,7 @@ import com.gamingmesh.jobs.i18n.Language;
 
 import net.Zrips.CMILib.Colors.CMIChatColor;
 
-public class demote implements Cmd {
+public class deluser implements Cmd {
 
     @Override
     public Boolean perform(Jobs plugin, CommandSender sender, String[] args) {

--- a/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
@@ -1,6 +1,8 @@
 package com.gamingmesh.jobs.commands.list;
 
 import com.gamingmesh.jobs.PlayerManager;
+import com.gamingmesh.jobs.stuff.Util;
+import net.Zrips.CMILib.Version.Schedulers.CMIScheduler;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
@@ -23,6 +25,20 @@ public class deluser implements Cmd {
             Language.sendMessage(sender, "general.error.noinfoByPlayer", "%playername%", args[0]);
             return true;
         }
+        Player pSender = (Player) sender;
+        java.util.UUID uuid = pSender.getUniqueId();
+
+        if (!Util.ADMINCONFIRM.contains(uuid)) {
+            Util.ADMINCONFIRM.add(uuid);
+
+            CMIScheduler.runTaskLater(plugin, () -> Util.ADMINCONFIRM.remove(uuid), 20 * Jobs.getGCManager().ConfirmExpiryTime);
+
+            Language.sendMessage(sender, "command.deluser.confirmationNeed", "%playername%", args[0],
+                    "[time]", Jobs.getGCManager().ConfirmExpiryTime);
+            return true;
+        }
+
+        Util.LEAVECONFIRM.remove(uuid);
 
         try {
             Player player = jPlayer.getPlayer();

--- a/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/deluser.java
@@ -1,17 +1,13 @@
 package com.gamingmesh.jobs.commands.list;
 
 import com.gamingmesh.jobs.PlayerManager;
-import com.gamingmesh.jobs.dao.JobsDAO;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 
 import com.gamingmesh.jobs.Jobs;
 import com.gamingmesh.jobs.commands.Cmd;
-import com.gamingmesh.jobs.container.Job;
 import com.gamingmesh.jobs.container.JobsPlayer;
 import com.gamingmesh.jobs.i18n.Language;
-
-import net.Zrips.CMILib.Colors.CMIChatColor;
 
 public class deluser implements Cmd {
 

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -588,6 +588,8 @@ public class LanguageManager {
             c.get("command.deluser.help.args", "[playername]");
             Jobs.getGCManager().getCommandArgs().put("deluser", Arrays.asList("[playername]"));
             c.get("command.deluser.output.target", "You have been removed from the jobs database.");
+            c.get("command.deluser.confirmationNeed", "&cAre you sure you want to delete &e[playername]&c from the database? This cannot be reversed! Type the command again within&6 [time] seconds &cto confirm!");
+
 
             c.get("command.grantxp.help.info", "Grants the player X experience in a job.");
             c.get("command.grantxp.help.args", "[playername] [jobname] [xp]");

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -584,6 +584,11 @@ public class LanguageManager {
             Jobs.getGCManager().getCommandArgs().put("demote", Arrays.asList("[playername]", "[jobname]", "[levels]"));
             c.get("command.demote.output.target", "You have been demoted %levelslost% levels in %jobname%.");
 
+            c.get("command.deluser.help.info", "Delete a player from the jobs database.");
+            c.get("command.deluser.help.args", "[playername]");
+            Jobs.getGCManager().getCommandArgs().put("deluser", Arrays.asList("[playername]"));
+            c.get("command.deluser.output.target", "You have been removed from the jobs database.");
+
             c.get("command.grantxp.help.info", "Grants the player X experience in a job.");
             c.get("command.grantxp.help.args", "[playername] [jobname] [xp]");
             Jobs.getGCManager().getCommandArgs().put("grantxp", Arrays.asList("[playername]", "[jobname]", "[xp]"));

--- a/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
+++ b/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
@@ -876,6 +876,22 @@ public abstract class JobsDAO {
         return map;
     }
 
+    public void delUser(UUID uuid) {
+        JobsConnection conn = getConnection();
+        if (conn == null)
+            return;
+
+        PreparedStatement prest = null;
+        try {
+            prest = conn.prepareStatement("DELETE FROM `" + DBTables.UsersTable.getTableName() + "` WHERE `" + UserTableFields.player_uuid.getCollumn() + "` = `" + uuid "`;`");
+            prest.execute();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        } finally {
+            close(prest);
+        }
+    }
+
     public void cleanUsers() {
         if (!Jobs.getGCManager().DBCleaningUsersUse)
             return;

--- a/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
+++ b/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
@@ -883,7 +883,7 @@ public abstract class JobsDAO {
 
         PreparedStatement prest = null;
         try {
-            prest = conn.prepareStatement("DELETE FROM `" + DBTables.UsersTable.getTableName() + "` WHERE `" + UserTableFields.player_uuid.getCollumn() + "` = `" + uuid "`;`");
+            prest = conn.prepareStatement("DELETE FROM `" + DBTables.UsersTable.getTableName() + "` WHERE `" + UserTableFields.player_uuid.getCollumn() + "` = `" + uuid + "`;`");
             prest.execute();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
+++ b/src/main/java/com/gamingmesh/jobs/dao/JobsDAO.java
@@ -883,7 +883,8 @@ public abstract class JobsDAO {
 
         PreparedStatement prest = null;
         try {
-            prest = conn.prepareStatement("DELETE FROM `" + DBTables.UsersTable.getTableName() + "` WHERE `" + UserTableFields.player_uuid.getCollumn() + "` = `" + uuid + "`;`");
+            prest = conn.prepareStatement("DELETE FROM `" + DBTables.UsersTable.getTableName() + "` WHERE `" + UserTableFields.player_uuid.getCollumn() + "` = ? ;");
+            prest.setString(1, uuid.toString());
             prest.execute();
         } catch (SQLException e) {
             e.printStackTrace();

--- a/src/main/java/com/gamingmesh/jobs/stuff/Util.java
+++ b/src/main/java/com/gamingmesh/jobs/stuff/Util.java
@@ -53,6 +53,9 @@ public final class Util {
 
     public static final List<UUID> LEAVECONFIRM = new ArrayList<>();
 
+    // for confirmation of irreversible admin commands such as deluser
+    public static final List<UUID> ADMINCONFIRM = new ArrayList<>();
+
     // for confirmation of skipping quest
     public static final List<UUID> SKIPCONFIRM = new ArrayList<>();
 

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -137,6 +137,9 @@ permissions:
   jobs.command.demote:
     description: Grants access to the demote command
     default: op
+  jobs.command.deluser:
+    description: Grants access to the deluser command
+    default: op
   jobs.command.grantxp:
     description: Grants access to the grantxp command
     default: op


### PR DESCRIPTION
Adds an admin command, requiring confirmation (and a new permission for it) to delete a user from the database entirely.  Useful in GDPR requests or for removing a banned player's stats quickly and much of the code will be used in future PRs  to transfer all jobs data from one player to another or delete a player from a single job.   