### PR TITLE
introduced config-option JobsTop.IncludeArchivedStats

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/PlayerManager.java
+++ b/src/main/java/com/gamingmesh/jobs/PlayerManager.java
@@ -55,6 +55,7 @@ import com.gamingmesh.jobs.container.JobItems;
 import com.gamingmesh.jobs.container.JobProgression;
 import com.gamingmesh.jobs.container.JobsMobSpawner;
 import com.gamingmesh.jobs.container.JobsPlayer;
+import com.gamingmesh.jobs.container.JobsTop;
 import com.gamingmesh.jobs.container.Log;
 import com.gamingmesh.jobs.container.PlayerInfo;
 import com.gamingmesh.jobs.container.PlayerPoints;
@@ -285,6 +286,8 @@ public class PlayerManager {
 
             Jobs.getJobsDAO().loadLog(jPlayer);
 
+            JobsTop.updateGlobalTop(jPlayer);
+
             return jPlayer;
         });
     }
@@ -490,6 +493,8 @@ public class PlayerManager {
 
             jPlayer.setArchivedJobs(aj);
         }
+
+        JobsTop.updateGlobalTop(jPlayer);
 
         return jPlayer;
     }

--- a/src/main/java/com/gamingmesh/jobs/commands/list/top.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/top.java
@@ -102,7 +102,17 @@ public class top implements Cmd {
                 continue;
 
             JobProgression progression = jPlayer.getJobProgression(job);
-            if(progression == null) continue; // Skip if the UUID has no progression in this job
+
+            if (progression == null) {
+                if (!Jobs.getGCManager().jobsTopIncludesArchivedStats)
+                    continue;
+
+                progression = jPlayer.getArchivedJobProgression(job);
+
+                if (progression == null)
+                    continue;
+            }
+
             if (Jobs.getGCManager().ShowToplistInScoreboard && sender instanceof Player)
                 ls.add(Jobs.getLanguage().getMessage("scoreboard.line",
                     "%number%", pi.getPositionForOutput(i),

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -84,6 +84,8 @@ public class GeneralConfigManager {
 
 	public List<String> JobsTopHiddenPlayers;
 
+	public boolean jobsTopIncludesArchivedStats;
+
 	public int jobExpiryTime, BlockProtectionDays, FireworkPower, ShootTime, blockOwnershipRange, globalblocktimer, globalBlockBreakTimer, CowMilkingTimer, InfoUpdateInterval, JobsTopAmount, PlaceholdersPage, ConfirmExpiryTime,
 			SegmentCount, BossBarTimer, AutoJobJoinDelay, DBCleaningJobsLvl, DBCleaningUsersDays, levelLossPercentageFromMax, levelLossPercentage, ToplistInScoreboardInterval;
 
@@ -1134,6 +1136,9 @@ public class GeneralConfigManager {
 		c.addComment("Commands.PageRow.JobsTop.HiddenPlayers", "List of player names who should be excluded from /jobs top & /jobs gtop");
 		JobsTopHiddenPlayers = c.get("Commands.PageRow.JobsTop.HiddenPlayers", Arrays.asList("Zrips"));
 		CMIList.toLowerCase(JobsTopHiddenPlayers);
+
+		c.addComment("Commands.PageRow.JobsTop.IncludeArchivedStats", "Whether to include archived level/experience in /jobs top & /jobs gtop");
+		jobsTopIncludesArchivedStats = c.get("Commands.PageRow.JobsTop.IncludeArchivedStats", false);
 
 		c.addComment("Commands.PageRow.Placeholders.AmountToShow", "Defines amount of placeholders to be shown in one page for /jobs placeholders");
 		PlaceholdersPage = c.get("Commands.PageRow.Placeholders.AmountToShow", 10);

--- a/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsPlayer.java
@@ -592,6 +592,9 @@ public class JobsPlayer {
             synchronized (progression) {
                 progression.add(new JobProgression(job, this, level, exp));
             }
+
+            JobsTop.updateGlobalTop(this);
+
             reloadMaxExperience();
             reloadLimits();
             reloadHonorific();
@@ -653,8 +656,10 @@ public class JobsPlayer {
         synchronized (progression) {
             if (progression.remove(getJobProgression(job))) {
 
-                job.removeFromTop(getUniqueId());
-                JobsTop.updateGlobalTop(getUniqueId(), getJobProgression());
+                if (!Jobs.getGCManager().jobsTopIncludesArchivedStats)
+                  job.removeFromTop(getUniqueId());
+
+                JobsTop.updateGlobalTop(this);
 
                 reloadMaxExperience();
                 reloadLimits();

--- a/src/main/java/com/gamingmesh/jobs/container/JobsTop.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobsTop.java
@@ -25,10 +25,12 @@ public class JobsTop {
 
     private static JobsTop globalTop = new JobsTop();
 
-    public static void updateGlobalTop(UUID uuid, List<JobProgression> progress) {
+    public static void updateGlobalTop(JobsPlayer jPlayer) {
         CompletableFuture.runAsync(() -> {
             int level = 0;
             double experience = 0;
+
+            List<JobProgression> progress = jPlayer.getJobProgression();
 
             synchronized (progress) {
                 for (JobProgression prog : progress) {
@@ -39,10 +41,23 @@ public class JobsTop {
                 }
             }
 
+            if (Jobs.getGCManager().jobsTopIncludesArchivedStats) {
+                Set<JobProgression> archivedProgress = jPlayer.getArchivedJobs().getArchivedJobs();
+
+                synchronized (archivedProgress) {
+                    for (JobProgression prog : archivedProgress) {
+                        if (prog.getLevel() == 1 && prog.getExperience() == 0)
+                            continue;
+                        level += prog.getLevel();
+                        experience += prog.getExperience();
+                    }
+                }
+            }
+
             if (level == 0 && experience == 0) {
-                globalTop.remove(uuid);
+                globalTop.remove(jPlayer.getUniqueId());
             } else
-                globalTop.update(uuid, level, experience);
+                globalTop.update(jPlayer.getUniqueId(), level, experience);
         });
     }
 
@@ -70,7 +85,7 @@ public class JobsTop {
         if (jPlayer == null)
             return;
         job.updateTop(jPlayer.getUniqueId(), level, experience);
-        JobsTop.updateGlobalTop(jPlayer.getUniqueId(), jPlayer.getJobProgression());
+        JobsTop.updateGlobalTop(jPlayer);
     }
 
     private final NavigableMap<Integer, NavigableMap<Double, Set<UUID>>> rankingMap = new TreeMap<>(Comparator.reverseOrder());


### PR DESCRIPTION
Greetings!

This rather concise patch gives users the option to select whether or not to include the statistics (level, experience) of archived jobs in `/jobs top` and `/jobs gtop`, seeing how multiple users desired this feature.

Also, I've added two more calls to update global top, seeing how we've noticed that in some cases, one had to join/leave jobs as for it to get updated; now, it simply pushes an update after loading the user from persistence.

I'd be super thankful if we could get this merged and thereby make it become available for the whole community.

Please let me know if you'd like me to make any further adjustments to my changes - I'm happy to do so.