### PR TITLE
add ForceKill action type for MythicMobs vanilla override support

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/container/ActionType.java
+++ b/src/main/java/com/gamingmesh/jobs/container/ActionType.java
@@ -37,6 +37,7 @@ public enum ActionType {
 	PLACE(CMIMaterial.BRICKS, ActionSubType.BLOCK, ActionSubType.PROTECTED),
 	KILL(CMIMaterial.DIAMOND_SWORD, ActionSubType.ENTITY),
 	MMKILL("MMKill", CMIMaterial.WOODEN_SWORD, ActionSubType.ENTITY, ActionSubType.CUSTOM),
+	FORCEKILL("ForceKill", CMIMaterial.IRON_SWORD, ActionSubType.ENTITY),
 	FISH(CMIMaterial.FISHING_ROD, ActionSubType.MATERIAL),
 	PYROFISHINGPRO("PyroFishingPro", CMIMaterial.PUFFERFISH, ActionSubType.CUSTOM),
 	CUSTOMFISHING("CustomFishing", CMIMaterial.TROPICAL_FISH, ActionSubType.CUSTOM),

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -1310,10 +1310,11 @@ public final class JobsPaymentListener implements Listener {
         if (killer.hasMetadata("NPC"))
             return;
 
-        if (Jobs.getGCManager().MythicMobsEnabled && JobsHook.getMythicMobsManager() != null
-            && JobsHook.getMythicMobsManager().isMythicMob(lVictim)) {
-            return;
-        }
+        // If MythicMobs handles this mob (custom mob or vanilla override), skip KILL to avoid
+        // double payment with MMKill. ForceKill is still dispatched further below, which allows
+        // server admins to reward kills on vanilla-override mobs by their vanilla entity type.
+        boolean isMythicMobEntity = Jobs.getGCManager().MythicMobsEnabled && JobsHook.getMythicMobsManager() != null
+            && JobsHook.getMythicMobsManager().isMythicMob(lVictim);
 
         Player pDamager = null;
 
@@ -1373,21 +1374,30 @@ public final class JobsPaymentListener implements Listener {
         if (notNpc && jDamager.getName().equalsIgnoreCase(((Player) lVictim).getName()))
             return;
 
-        if (Jobs.getGCManager().payForStackedEntities) {
-            if (JobsHook.WildStacker.isEnabled()) {
-                for (int i = 0; i < JobsHook.getWildStackerManager().getEntityAmount(lVictim) - 1; i++) {
-                    Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
-                }
-            } else if (JobsHook.StackMob.isEnabled() && JobsHook.getStackMobManager().isStacked(lVictim)) {
-                StackEntity stack = JobsHook.getStackMobManager().getStackEntity(lVictim);
-                if (stack != null) {
-                    Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
-                    return;
+        if (!isMythicMobEntity) {
+            if (Jobs.getGCManager().payForStackedEntities) {
+                if (JobsHook.WildStacker.isEnabled()) {
+                    for (int i = 0; i < JobsHook.getWildStackerManager().getEntityAmount(lVictim) - 1; i++) {
+                        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
+                        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.FORCEKILL), killer, lVictim);
+                    }
+                } else if (JobsHook.StackMob.isEnabled() && JobsHook.getStackMobManager().isStacked(lVictim)) {
+                    StackEntity stack = JobsHook.getStackMobManager().getStackEntity(lVictim);
+                    if (stack != null) {
+                        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
+                        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.FORCEKILL), killer, lVictim);
+                        return;
+                    }
                 }
             }
+
+            Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
         }
 
-        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.KILL), killer, lVictim);
+        // ForceKill always fires regardless of MythicMobs status, using the vanilla entity type name.
+        // This allows rewarding kills on MythicMobs vanilla-override mobs (e.g. a Zombie with custom
+        // loot) by configuring them under ForceKill: instead of Kill: or MMKill:.
+        Jobs.action(jDamager, new EntityActionInfo(lVictim, ActionType.FORCEKILL), killer, lVictim);
 
         // Payment for killing player with particular job, except NPC's
         if (notNpc) {


### PR DESCRIPTION
## Problem
When MythicMobs applies a **vanilla override** to a base Minecraft mob (e.g. a Zombie configured to drop a diamond), the mob becomes invisible to both existing kill actions:
- `Kill` skips it because `isMythicMob()` returns `true`
- `MMKill` skips it because the mob has no custom MythicMobs internal name

Players receive **no job reward** when killing vanilla-override mobs.

## Solution
Adds a new `ForceKill` action type that bypasses the MythicMobs check and always fires on entity death, matching by vanilla entity type name (same as `Kill`).

<img width="307" height="103" alt="image" src="https://github.com/user-attachments/assets/38c8e62a-0f0e-48cd-ac4f-6fbd462aa059" />

## Changes
- `ActionType.java` — added `FORCEKILL` enum entry
- `JobsPaymentListener.java` — `KILL` is gated behind `!isMythicMobEntity`, `ForceKill` always dispatches

No impact on existing `Kill` or `MMKill` configurations.