### PR TITLE
Feat: Add RoseStacker compatibility and fix "rapid" mode BossBar updates flickering

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>Jobs</groupId>
 	<artifactId>jobs</artifactId>
-	<version>5.2.6.5-RoseStacker</version>
+	<version>5.2.6.5</version>
 	<name>Jobs</name>
 	<url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>Jobs</groupId>
 	<artifactId>jobs</artifactId>
-	<version>5.2.6.5</version>
+	<version>5.2.6.4</version>
 	<name>Jobs</name>
 	<url>http://maven.apache.org</url>
 

--- a/pom.xml
+++ b/pom.xml
@@ -191,6 +191,13 @@
 			<version>2.3.4</version>
 			<scope>provided</scope>
 		</dependency>
+		<!-- RoseStacker -->
+		<dependency>
+			<groupId>dev.rosewood</groupId>
+			<artifactId>rosestacker</artifactId>
+			<version>1.5.40</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>
@@ -232,6 +239,11 @@
 		<repository>
 			<id>bg-repo</id>
 			<url>https://repo.bg-software.com/repository/api/</url>
+		</repository>
+		<!-- RoseStacker -->
+		<repository>
+			<id>rosewood-repo</id>
+			<url>https://repo.rosewooddev.io/repository/public/</url>
 		</repository>
 		<!-- MyPet -->
 		<!--		<repository>-->

--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,10 @@
 	xmlns="http://maven.apache.org/POM/4.0.0"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>Jobs</groupId>
 	<artifactId>jobs</artifactId>
-	<version>5.2.6.4</version>
+	<version>5.2.6.5-RoseStacker</version>
 	<name>Jobs</name>
 	<url>http://maven.apache.org</url>
 
@@ -16,14 +17,14 @@
 	</properties>
 
 	<dependencies>
-        <!-- Spigot API -->
+		<!-- Spigot API -->
 		<dependency>
 			<groupId>org.spigotmc</groupId>
 			<artifactId>spigot-api</artifactId>
-			<version>1.21.10-R0.1-SNAPSHOT</version>
+			<version>1.21.11-R0.2-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
-        <!-- Mojang Authlib -->
+		<!-- Mojang Authlib -->
 		<dependency>
 			<groupId>com.mojang</groupId>
 			<artifactId>authlib</artifactId>
@@ -113,15 +114,12 @@
 					<artifactId>paperlib</artifactId>
 				</exclusion>
 				<exclusion>
-					<groupId>
-						com.sk89q.worldedit.worldedit-libs
-					</groupId>
+					<groupId>com.sk89q.worldedit.worldedit-libs</groupId>
 					<artifactId>bukkit</artifactId>
 				</exclusion>
 				<exclusion>
 					<groupId>net.java.truevfs</groupId>
-					<artifactId>
-						truevfs-profile-default_2.13
+					<artifactId>truevfs-profile-default_2.13
 					</artifactId>
 				</exclusion>
 				<exclusion>
@@ -175,8 +173,8 @@
 			<artifactId>mypet</artifactId>
 			<version>3.11-SNAPSHOT</version>
 			<scope>system</scope>
-			<!--			 Temporary solution for replacing repository -->
-			<systemPath>${basedir}/libs/mypet-3.12.jar</systemPath> 
+			<!-- Temporary solution for replacing repository -->
+			<systemPath>${basedir}/libs/mypet-3.12.jar</systemPath>
 		</dependency>
 		<!-- PyroFishingPro -->
 		<dependency>
@@ -184,14 +182,15 @@
 			<artifactId>pyrofishingpro</artifactId>
 			<version>4.9.1</version>
 			<scope>system</scope>
+			<!-- Temporary solution for replacing repository -->
 			<systemPath>${basedir}/libs/PyroFishingPro-4.9.1.jar</systemPath>
 		</dependency>
 		<dependency>
-            <groupId>net.momirealms</groupId>
-            <artifactId>custom-fishing</artifactId>
-            <version>2.3.4</version>
-            <scope>provided</scope>
-        </dependency>
+			<groupId>net.momirealms</groupId>
+			<artifactId>custom-fishing</artifactId>
+			<version>2.3.4</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>
@@ -228,16 +227,17 @@
 		<!-- PlaceholderAPI -->
 		<repository>
 			<id>placeholderapi</id>
-			<url>
-				https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
+			<url>https://repo.extendedclip.com/content/repositories/placeholderapi/</url>
 		</repository>
 		<repository>
 			<id>bg-repo</id>
 			<url>https://repo.bg-software.com/repository/api/</url>
 		</repository>
 		<!-- MyPet -->
-		<!--<repository> <id>mypet-repo</id> <url>https://repo.mypet-plugin.de/</url>
-			</repositor> -->
+		<!--		<repository>-->
+		<!--			<id>mypet-repo</id>-->
+		<!--			<url>https://repo.mypet-plugin.de/</url>-->
+		<!--		</repository>-->
 	</repositories>
 	<!-- Builds Plugin -->
 	<build>
@@ -254,12 +254,12 @@
 		<plugins>
 			<!-- Make a Jar -->
 			<plugin>
-                <groupId>org.apache.maven.plugins</groupId>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-                <version>3.11.0</version>
+				<version>3.11.0</version>
 				<configuration>
-                    <source>${maven.compiler.source}</source>
-                    <target>${maven.compiler.target}</target>
+					<source>${maven.compiler.source}</source>
+					<target>${maven.compiler.target}</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -888,6 +888,7 @@ public final class Jobs extends JavaPlugin {
 		JobsHook.PyroFishingPro.registerListener();
 		JobsHook.mcMMO.registerListener();
 		JobsHook.MythicMobs.registerListener();
+		JobsHook.RoseStacker.registerListener();
 
 		CMIMessages.consoleMessage("&eListeners registered successfully");
 	}

--- a/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
@@ -29,12 +29,22 @@ public class BossBarManager {
         if (Version.getCurrent().isLower(Version.v1_9_R1) || player == null)
             return;
 
-        for (JobProgression oneJob : player.getJobProgression()) {
-            if (oneJob.getLastExperience() != 0) {
-                ShowJobProgression(player, oneJob, oneJob.getLastExperience());
-            }
+        synchronized (player.getUpdateBossBarFor()) {
+            if (player.getUpdateBossBarFor().contains("pending"))
+                return;
+            player.getUpdateBossBarFor().add("pending");
         }
-        player.getUpdateBossBarFor().clear();
+
+        CMIScheduler.runTask(Jobs.getInstance(), () -> {
+            synchronized (player.getUpdateBossBarFor()) {
+                player.getUpdateBossBarFor().remove("pending");
+            }
+            for (JobProgression oneJob : player.getJobProgression()) {
+                if (oneJob.getLastExperience() != 0) {
+                    ShowJobProgression(player, oneJob, oneJob.getLastExperience());
+                }
+            }
+        });
     }
 
     public void ShowJobProgression(final JobsPlayer player, final JobProgression jobProg, double expGain) {

--- a/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/GeneralConfigManager.java
@@ -549,7 +549,7 @@ public class GeneralConfigManager {
 		c.addComment("pay-for-above", "When enabled we will try to pay player for blocks above broken ones. This only applies to sugarcane, bamboo, kelp and weeping_vines");
 		payForAbove = c.get("pay-for-above", false);
 
-		c.addComment("pay-for-stacked-entities", "Allows to pay for stacked entities for each one. Requires StackMob or WildStacker.");
+		c.addComment("pay-for-stacked-entities", "Allows to pay for stacked entities for each one. Requires StackMob, WildStacker or RoseStacker.");
 		payForStackedEntities = c.get("pay-for-stacked-entities", false);
 
 		c.addComment("allow-pay-for-durability-loss", "Allows, when losing maximum durability of item then it does not pay the player until it is repaired.",

--- a/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
@@ -13,6 +13,8 @@ import com.gamingmesh.jobs.hooks.MythicMobs.MythicMobs5Listener;
 import com.gamingmesh.jobs.hooks.WorldGuard.WorldGuardManager;
 import com.gamingmesh.jobs.hooks.blockTracker.BlockTrackerManager;
 import com.gamingmesh.jobs.hooks.pyroFishingPro.PyroFishingProListener;
+import com.gamingmesh.jobs.hooks.roseStacker.RoseStackerHandler;
+import com.gamingmesh.jobs.hooks.roseStacker.RoseStackerListener;
 import com.gamingmesh.jobs.hooks.stackMob.StackMobManager;
 import com.gamingmesh.jobs.hooks.wildStacker.WildStackerHandler;
 import com.gamingmesh.jobs.listeners.JobsCustomFishingPaymentListener;
@@ -41,6 +43,26 @@ public enum JobsHook {
             JobsHook.stackMobHandler = new StackMobManager();
             printDetectedMessage(this);
             return true;
+        }
+    },
+    RoseStacker {
+        @Override
+        protected boolean init() {
+            if (!isPresent())
+                return false;
+
+            JobsHook.roseStackerHandler = new RoseStackerHandler();
+            printDetectedMessage(this);
+            return true;
+        }
+
+        @Override
+        public void registerListener() {
+            if (!isPresent())
+                return;
+
+            JavaPlugin.getPlugin(Jobs.class).getServer().getPluginManager().registerEvents(new RoseStackerListener(), JavaPlugin.getPlugin(Jobs.class));
+            printListenerMessage(this);
         }
     },
     WildStacker {
@@ -214,6 +236,7 @@ public enum JobsHook {
     private static MythicMobs5 mythicManager;
     private static MyPetManager myPetManager;
     private static WorldGuardManager worldGuardManager;
+    private static RoseStackerHandler roseStackerHandler;
     private static StackMobManager stackMobHandler;
     private static WildStackerHandler wildStackerHandler;
     private static BlockTrackerManager blockTrackerManager;
@@ -227,6 +250,10 @@ public enum JobsHook {
 
     public static StackMobManager getStackMobManager() {
         return stackMobHandler;
+    }
+
+    public static RoseStackerHandler getRoseStackerManager() {
+        return roseStackerHandler;
     }
 
     public static WildStackerHandler getWildStackerManager() {

--- a/src/main/java/com/gamingmesh/jobs/hooks/roseStacker/RoseStackerHandler.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/roseStacker/RoseStackerHandler.java
@@ -1,0 +1,21 @@
+package com.gamingmesh.jobs.hooks.roseStacker;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import dev.rosewood.rosestacker.api.RoseStackerAPI;
+import dev.rosewood.rosestacker.stack.StackedEntity;
+
+import net.Zrips.CMILib.Version.Version;
+
+public class RoseStackerHandler {
+
+    public int getEntityAmount(LivingEntity entity) {
+
+        if (entity instanceof Player || Version.isCurrentEqualOrHigher(Version.v1_8_R1) && entity instanceof org.bukkit.entity.ArmorStand)
+            return 0;
+
+        StackedEntity stacked = RoseStackerAPI.getInstance().getStackedEntity(entity);
+        return stacked == null ? 0 : stacked.getStackSize();
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/hooks/roseStacker/RoseStackerListener.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/roseStacker/RoseStackerListener.java
@@ -1,0 +1,56 @@
+package com.gamingmesh.jobs.hooks.roseStacker;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.actions.EntityActionInfo;
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.container.JobsPlayer;
+
+import dev.rosewood.rosestacker.event.EntityStackMultipleDeathEvent;
+
+public class RoseStackerListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onEntityStackMultipleDeath(EntityStackMultipleDeathEvent event) {
+        if (!Jobs.getGCManager().payForStackedEntities)
+            return;
+
+        Player killer = event.getKiller();
+        if (killer == null)
+            return;
+
+        if (!Jobs.getGCManager().canPerformActionInWorld(killer.getWorld()))
+            return;
+
+        if (!Jobs.getPermissionHandler().hasWorldPermission(killer, killer.getLocation().getWorld().getName()))
+            return;
+
+        JobsPlayer jPlayer = Jobs.getPlayerManager().getJobsPlayer(killer);
+        if (jPlayer == null)
+            return;
+
+        LivingEntity victim = event.getStack().getEntity();
+
+        // entityKillCount includes the main entity which is already handled by the standard EntityDeathEvent listener
+        // so we only pay for the extra kills (entityKillCount - 1)
+        int extraKills = event.getEntityKillCount() - 1;
+        if (extraKills <= 0) return;
+
+        Runnable actionTask = () -> {
+            for (int i = 0; i < extraKills; i++) {
+                Jobs.action(jPlayer, new EntityActionInfo(victim, ActionType.KILL), killer, victim);
+            }
+        };
+
+        if (event.isAsynchronous()) {
+            org.bukkit.Bukkit.getScheduler().runTask(Jobs.getInstance(), actionTask);
+        } else {
+            actionTask.run();
+        }
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsPaymentListener.java
@@ -358,6 +358,10 @@ public final class JobsPaymentListener implements Listener {
                 for (int i = 0; i < JobsHook.getWildStackerManager().getEntityAmount((LivingEntity) entity) - 1; i++) {
                     Jobs.action(jDamager, new CustomKillInfo(typeString, ActionType.SHEAR));
                 }
+            } else if (JobsHook.RoseStacker.isEnabled()) {
+                for (int i = 0; i < JobsHook.getRoseStackerManager().getEntityAmount((LivingEntity) entity) - 1; i++) {
+                    Jobs.action(jDamager, new CustomKillInfo(typeString, ActionType.SHEAR));
+                }
             } else if (JobsHook.StackMob.isEnabled() && JobsHook.getStackMobManager().isStacked((LivingEntity) entity)) {
                 StackEntity stack = JobsHook.getStackMobManager().getStackEntity((LivingEntity) entity);
                 if (stack != null) {
@@ -581,6 +585,10 @@ public final class JobsPaymentListener implements Listener {
         if (Jobs.getGCManager().payForStackedEntities) {
             if (JobsHook.WildStacker.isEnabled()) {
                 for (int i = 0; i < JobsHook.getWildStackerManager().getEntityAmount(animal) - 1; i++) {
+                    Jobs.action(jDamager, new EntityActionInfo(animal, ActionType.TAME));
+                }
+            } else if (JobsHook.RoseStacker.isEnabled()) {
+                for (int i = 0; i < JobsHook.getRoseStackerManager().getEntityAmount(animal) - 1; i++) {
                     Jobs.action(jDamager, new EntityActionInfo(animal, ActionType.TAME));
                 }
             } else if (JobsHook.StackMob.isEnabled() && JobsHook.getStackMobManager().isStacked(animal)) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,7 @@ website: https://www.spigotmc.org/resources/4216/
 authors: [Zrips]
 contributors: [montlikadani]
 depend: [CMILib]
-softdepend: [Vault, Essentials, MythicMobs, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, StackMob, PyroFishingPro, BlockTracker, CustomFishing]
+softdepend: [Vault, Essentials, MythicMobs, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, RoseStacker, StackMob, PyroFishingPro, BlockTracker, CustomFishing]
 commands:
   jobs:
     description: Jobs


### PR DESCRIPTION
### Description
This PR introduces native compatibility for the **RoseStacker** plugin and resolves a visual flickering issue with the BossBar during rapid sequential payments (e.g., multi-kills).

**1. RoseStacker Integration:**
Previously, the `pay-for-stacked-entities` feature only supported WildStacker and StackMob. This PR adds support for **[RoseStacker](https://github.com/Rosewood-Development/RoseStacker)**:
* Created `RoseStackerHandler` to fetch stack sizes for `TAME` and `SHEAR` actions using the `RoseStackerAPI`.
* Created `RoseStackerListener` which natively listens to RoseStacker's `EntityStackMultipleDeathEvent`. This ensures accurate payments when a player kills an entire stack at once (MultiKill feature), correctly triggering `Jobs.action()` for the extra entities killed.
* Added `RoseStacker` to the `plugin.yml` soft-depends.

**2. BossBar Debounce Optimization:**
While testing the MultiKill feature, I noticed that rapid, simultaneous payments (e.g., killing a stack of 3 mobs) caused the BossBar to flicker and show intermediate experience gains (e.g., showing `+2` then `+4` instead of `+6`). The ActionBar handles this well via its `paymentCache`, but the BossBar was updating and resetting `lastExperience` instantly for each event.
* Implemented a thread-safe 1-tick debounce in `BossBarManager.java`.
* Leveraged the existing `player.getUpdateBossBarFor()` list to prevent the `ShowJobProgression` task from overlapping within the same tick.
* Rapid sequential job actions now accumulate their XP cleanly, and the BossBar displays the total combined gain perfectly in a single visual update.

### How to test:
1. Enable `pay-for-stacked-entities: true` and set `BossBar.Messages.DefaultState: Rapid` in `generalConfig.yml`.
2. Stack several mobs using RoseStacker (with MultiKill enabled).
3. Kill the stack in a single hit.
4. Verify that you receive the correct amount of money/exp for the entire stack.
5. Verify that the BossBar shows a single, clean aggregated update (e.g., `+10`) instead of flickering through intermediate values.

### Checklist:
- [x] I have tested these changes on a local server.
- [x] The code follows the existing style and architecture of the JobsReborn plugin.
- [x] `mvn clean compile` and `mvn package` complete without special errors.
