### PR TITLE
Add `%money%` placeholder support for BossBar

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -1383,6 +1383,7 @@ public final class Jobs extends JavaPlugin {
 					getLoging().recordToLog(jPlayer, info, amounts);
 				}
 
+				prog.setLastMoney(prog.getLastMoney() + income);
 				if (prog.addExperience(expAmount))
 					getPlayerManager().performLevelUp(jPlayer, prog.getJob(), oldLevel);
 			}
@@ -1488,6 +1489,7 @@ public final class Jobs extends JavaPlugin {
 			getLoging().recordToLog(jPlayer, info, payment.getPayment());
 		}
 
+		prog.setLastMoney(prog.getLastMoney() + payment.get(CurrencyType.MONEY));
 		if (prog.addExperience(expPayment))
 			getPlayerManager().performLevelUp(jPlayer, prog.getJob(), oldLevel);
 	}

--- a/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/BossBarManager.java
@@ -30,24 +30,28 @@ public class BossBarManager {
             return;
 
         for (JobProgression oneJob : player.getJobProgression()) {
-            if (oneJob.getLastExperience() != 0) {
-                ShowJobProgression(player, oneJob, oneJob.getLastExperience());
+            if (oneJob.getLastExperience() != 0 || oneJob.getLastMoney() != 0) {
+                ShowJobProgression(player, oneJob, oneJob.getLastExperience(), oneJob.getLastMoney());
             }
         }
         player.getUpdateBossBarFor().clear();
     }
 
     public void ShowJobProgression(final JobsPlayer player, final JobProgression jobProg, double expGain) {
+        ShowJobProgression(player, jobProg, expGain, 0D);
+    }
+
+    public void ShowJobProgression(final JobsPlayer player, final JobProgression jobProg, double expGain, double moneyGain) {
         if (Version.getCurrent().isLower(Version.v1_9_R1) || Jobs.getGCManager().BossBarsMessageDefault.equals(MessageToggleState.Off))
             return;
 
         if (ToggleBarHandling.getBossBarState(player.getUniqueId()).equals(MessageToggleState.Off))
             return;
 
-        showJobProgressionInTask(player, jobProg, expGain);
+        showJobProgressionInTask(player, jobProg, expGain, moneyGain);
     }
 
-    private static synchronized void showJobProgressionInTask(final JobsPlayer player, final JobProgression jobProg, double expGain) {
+    private static synchronized void showJobProgressionInTask(final JobsPlayer player, final JobProgression jobProg, double expGain, double moneyGain) {
         BossBar bar = null;
         BossBarInfo oldOne = null;
         for (BossBarInfo one : player.getBossBarInfo()) {
@@ -66,12 +70,18 @@ public class BossBarManager {
             gain = Jobs.getLanguage().getMessage("command.stats.bossBarGain", "%gain%", gain);
         }
 
+        String money = "";
+        if (moneyGain != 0) {
+            money = (moneyGain > 0 ? "+" : "") + String.format(Jobs.getGCManager().getDecimalPlacesMoney(), moneyGain);
+        }
+
         String message = Jobs.getLanguage().getMessage("command.stats.bossBarOutput",
             "%joblevel%", jobProg.getLevelFormatted(),
             jobProg.getJob(),
             "%jobxp%", CurrencyType.EXP.format(jobProg.getExperience()),
             "%jobmaxxp%", jobProg.getMaxExperience(),
-            "%gain%", gain);
+            "%gain%", gain,
+            "%money%", money);
 
         if (bar == null) {
             bar = initBossBar(player, jobProg, message);
@@ -106,6 +116,7 @@ public class BossBarManager {
             }, Jobs.getGCManager().BossBarTimer * 20L));
 
         jobProg.setLastExperience(0D);
+        jobProg.setLastMoney(0D);
     }
 
     private static BossBar initBossBar(final JobsPlayer player, final JobProgression jobProg, String message) {

--- a/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
+++ b/src/main/java/com/gamingmesh/jobs/config/LanguageManager.java
@@ -308,7 +308,7 @@ public class LanguageManager {
             c.get("command.stats.error.nojob", "Please join a job first.");
             c.get("command.stats.output.Level", "&7Level &f%joblevel% &7for &f%jobname%&7: &f%jobxp%&7/&f%jobmaxxp%&7xp");
             c.get("command.stats.output.maxLevel", "    &2Max    &7Level &f%joblevel% &7for &f%jobname%");
-            c.get("command.stats.bossBarOutput", "Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%");
+            c.get("command.stats.bossBarOutput", "Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%");
             c.get("command.stats.bossBarGain", " &7(&f%gain%&7)");
             c.get("command.stats.barEmpty", "&7\u258F");
             c.get("command.stats.barFull", "&2\u258F");

--- a/src/main/java/com/gamingmesh/jobs/container/JobProgression.java
+++ b/src/main/java/com/gamingmesh/jobs/container/JobProgression.java
@@ -31,6 +31,7 @@ public class JobProgression {
 	private JobsPlayer jPlayer;
 	private double experience;
 	private double lastExperience = 0;
+	private double lastMoney = 0;
 	private int level;
 	private transient int maxExperience = -1;
 	private long leftOn = 0;
@@ -298,6 +299,14 @@ public class JobProgression {
 
 	public void setLastExperience(double lastExperience) {
 		this.lastExperience = lastExperience;
+	}
+
+	public double getLastMoney() {
+		return lastMoney;
+	}
+
+	public void setLastMoney(double lastMoney) {
+		this.lastMoney = lastMoney;
 	}
 
 }

--- a/src/main/resources/locale/messages_bg.yml
+++ b/src/main/resources/locale/messages_bg.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_bg.yml
+++ b/src/main/resources/locale/messages_bg.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from%\ 
-
-        &7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -261,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7New quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_bg.yml
+++ b/src/main/resources/locale/messages_bg.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_bg.yml
+++ b/src/main/resources/locale/messages_bg.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from%\ 
+
+        &7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_cs.yml
+++ b/src/main/resources/locale/messages_cs.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_cs.yml
+++ b/src/main/resources/locale/messages_cs.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Od levelu: %from% \n&7Do levelu: %until%"
+      hoverLevelLimits: "&7Od levelu: %from%\ 
+
+        &7Do levelu: %until%"
   edititembonus:
     help:
       info: Upravit bonus předmětu
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klikni pro preskoceni questu'
       skips: '&7Leva preskoci: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Novy quest za: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Novy quest za: [time]"
   fire:
     help:
       info: Vyhodit hrace z prace.

--- a/src/main/resources/locale/messages_cs.yml
+++ b/src/main/resources/locale/messages_cs.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_cs.yml
+++ b/src/main/resources/locale/messages_cs.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Od levelu: %from%\ 
-
-        &7Do levelu: %until%"
+      hoverLevelLimits: "&7Od levelu: %from% \n&7Do levelu: %until%"
   edititembonus:
     help:
       info: Upravit bonus předmětu
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klikni pro preskoceni questu'
       skips: '&7Leva preskoci: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Novy quest za: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Novy quest za: [time]"
   fire:
     help:
       info: Vyhodit hrace z prace.

--- a/src/main/resources/locale/messages_cs.yml
+++ b/src/main/resources/locale/messages_cs.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_de.yml
+++ b/src/main/resources/locale/messages_de.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% für %jobname%:%jobxp%/%jobmaxxp% XP'
       max-level: '     &c Maximales Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_de.yml
+++ b/src/main/resources/locale/messages_de.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Von Level: %from% \n&7Bis Level: %until%"
+      hoverLevelLimits: "&7Von Level: %from%\ 
+
+        &7Bis Level: %until%"
   edititembonus:
     help:
       info: Itemboostbonus bearbeiten
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% für %jobname%:%jobxp%/%jobmaxxp% XP'
       max-level: '     &c Maximales Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -487,7 +489,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klicke um die Quest zu überspringen.'
       skips: '&7So oft darfst du noch überspringen: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Neue Quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Neue Quest in: [time]"
   fire:
     help:
       info: Entlasse den Spieler aus diesem Beruf.

--- a/src/main/resources/locale/messages_de.yml
+++ b/src/main/resources/locale/messages_de.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Von Level: %from%\ 
-
-        &7Bis Level: %until%"
+      hoverLevelLimits: "&7Von Level: %from% \n&7Bis Level: %until%"
   edititembonus:
     help:
       info: Itemboostbonus bearbeiten
@@ -489,11 +487,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klicke um die Quest zu überspringen.'
       skips: '&7So oft darfst du noch überspringen: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Neue Quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Neue Quest in: [time]"
   fire:
     help:
       info: Entlasse den Spieler aus diesem Beruf.

--- a/src/main/resources/locale/messages_de.yml
+++ b/src/main/resources/locale/messages_de.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% für %jobname%:%jobxp%/%jobmaxxp% XP'
       max-level: '     &c Maximales Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_de.yml
+++ b/src/main/resources/locale/messages_de.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% für %jobname%:%jobxp%/%jobmaxxp% XP'
       max-level: '     &c Maximales Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_es.yml
+++ b/src/main/resources/locale/messages_es.yml
@@ -256,7 +256,7 @@ command:
     output:
       Level: '&7Nivel &f%joblevel% &7de &f%jobname%&7: &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2Max    &7Nivel &f%joblevel% &7de &f%jobname%'
-    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain%'
+    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_es.yml
+++ b/src/main/resources/locale/messages_es.yml
@@ -77,7 +77,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Desde el nivel: %from% \n&7Hasta el nivel: %until%"
+      hoverLevelLimits: "&7Desde el nivel: %from%\ 
+
+        &7Hasta el nivel: %until%"
   edititembonus:
     help:
       info: Editar bonificación de impulso de item
@@ -98,12 +100,10 @@ command:
       mcmmo: ' &eBonificacion McMMO: &2%money% &6%points% &e%exp%'
       final: ' &eBonificacion final: &2%money% &6%points% &e%exp%'
       specialPrefix: '&6*'
-      finalExplanation: ' &eNo se incluye la prima de Mascota o la penalización de
-        proximidad de spawner.'
+      finalExplanation: ' &eNo se incluye la prima de Mascota o la penalización de proximidad de spawner.'
   convert:
     help:
-      info: Convierte el sistema de base de datos en otro tipo. De SQLite a MySQL
-        o viceversa.
+      info: Convierte el sistema de base de datos en otro tipo. De SQLite a MySQL o viceversa.
       args: ''
   limit:
     help:
@@ -112,16 +112,13 @@ command:
     output:
       moneytime: '&eTiempo restante hasta que el Salario vuelva a la normalidad: &2%time%'
       moneyLimit: '&eLímite de Pago: &2%current%&e/&2%total%'
-      exptime: '&eTiempo restante hasta que la Experiencia vuelva a la normalidad:
-        &2%time%'
+      exptime: '&eTiempo restante hasta que la Experiencia vuelva a la normalidad: &2%time%'
       expLimit: '&eLímite de Experiencia: &2%current%&e/&2%total%'
-      pointstime: '&eTiempo restante hasta que los Puntos vuelvan a la normalidad:
-        &2%time%'
+      pointstime: '&eTiempo restante hasta que los Puntos vuelvan a la normalidad: &2%time%'
       pointsLimit: '&eLímite de Puntos: &2%current%&e/&2%total%'
       reachedmoneylimit: '&4Has alcanzado el salario máximo permitido por minuto!'
       reachedmoneylimit2: '&ePuedes comprobar el límite con el conjuro &2/jobs limit'
-      reachedmoneylimit3: '&eEl dinero ganado ahora se reduce exponencialmente...
-        ¡Pero aún ganas un poco!'
+      reachedmoneylimit3: '&eEl dinero ganado ahora se reduce exponencialmente... ¡Pero aún ganas un poco!'
       reachedexplimit: '&4Has alcanzado el límite de Experiencia obtenida por minuto!'
       reachedexplimit2: '&ePuedes comprobar el límite con el conjuro &2/jobs limit'
       reachedpointslimit: '&4Haz alcanzado el límite de Puntos obtenidos por minuto!'
@@ -134,8 +131,7 @@ command:
     output:
       notenabled: '&eNo habilitado.'
       invalidname: '&eNombre de mundo invalido'
-      reseted: '&eLos datos de la región de exploración se han restablecido para:
-        &2%worldname%'
+      reseted: '&eLos datos de la región de exploración se han restablecido para: &2%worldname%'
   resetlimit:
     help:
       info: Reinicia los límites de pago de jugadores.
@@ -168,8 +164,7 @@ command:
     output:
       set: '&eSe ha establecido la cantidad de &6%amount% &epuntos (a &6%playername%&e)'
       add: '&Se han añadido &6%amount%&e puntos a &6%playername%&e. Total: &6%total%'
-      take: '&eEl jugador (&6%playername%&e) ha perdido &6%amount% &epuntos. Ahora
-        tiene &6%total%'
+      take: '&eEl jugador (&6%playername%&e) ha perdido &6%amount% &epuntos. Ahora tiene &6%total%'
   editjobs:
     help:
       info: Modificar la profesión actual.
@@ -188,12 +183,10 @@ command:
         newValue: '&eIntroduce el nuevo valor'
         enter: '&eIntroduce un nombre nuevo o clic '
         hand: '&6IZQUIERDO '
-        handHover: '&6Clic izquierdo para obtener información sobre el objeto de tu
-          mano'
+        handHover: '&6Clic izquierdo para obtener información sobre el objeto de tu mano'
         or: '&eo '
         look: '&6MIRALO'
-        lookHover: '&6Clic izquierdo para obtener información sobre el bloque que
-          estás mirando'
+        lookHover: '&6Clic izquierdo para obtener información sobre el bloque que estás mirando'
   editquests:
     help:
       info: Editar misiones actuales.
@@ -256,7 +249,7 @@ command:
     output:
       Level: '&7Nivel &f%joblevel% &7de &f%jobname%&7: &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2Max    &7Nivel &f%joblevel% &7de &f%jobname%'
-    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain%'
+    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'
@@ -278,8 +271,7 @@ command:
       cantOpen: '&cNo se puede abrir esta página'
       NoPermForItem: '&cNo tienes permiso para obtener este item!'
       NoPermToBuy: '&cNo tienes permiso para comprar este item.'
-      NoJobReqForitem: '&cNo estás en la profesión necesaria (&6%jobname%&e) y no
-        tienes el nivel (&6%joblevel%&e) necesario.'
+      NoJobReqForitem: '&cNo estás en la profesión necesaria (&6%jobname%&e) y no tienes el nivel (&6%joblevel%&e) necesario.'
       NoPoints: '&cNo tienes puntos suficientes.'
       NoMoney: '&cNo tienes suficiente dinero'
       NoTotalLevel: '&cEl nivel de la profesión es demasiado bajo (%totalLevel%)&c.'
@@ -292,8 +284,7 @@ command:
       nojob: No hay profesiones guardadas.
   give:
     help:
-      info: Obtener el item a partir del nombre o la categoría. El nombre de jugador
-        es opcional.
+      info: Obtener el item a partir del nombre o la categoría. El nombre de jugador es opcional.
       args: '[playername] [jobname] [items/limiteditems] [jobitemname]'
     output:
       notonline: '&4El jugador con ese nombre no está conectado!'
@@ -302,10 +293,8 @@ command:
     help:
       title: '&2*** &ePROFESIONES&2 ***'
       info: Muestra los detalles de la profesión.
-      penalty: '&eTrabajar en esta profesión conlleva una penalización del &c[penalty]%
-        &eporque hay muchos trabajadores.'
-      bonus: '&eTrabajar en esta profesión implica obtener una prima del &2[bonus]%
-        &eporque hay pocos trabajadores.'
+      penalty: '&eTrabajar en esta profesión conlleva una penalización del &c[penalty]% &eporque hay muchos trabajadores.'
+      bonus: '&eTrabajar en esta profesión implica obtener una prima del &2[bonus]% &eporque hay pocos trabajadores.'
       args: '[jobname] [action]'
       actions: '&eAcciones validas: &f%actions%'
       max: ' - &enivel máximo:&f '
@@ -350,8 +339,7 @@ command:
         none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos.
       mmkill:
         info: '&eMMKill'
-        none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos
-          míticos.
+        none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos míticos.
       fish:
         info: '&ePescar'
         none: Con la profesión de %jobname% no vas a recibir dinero por pescar peces.
@@ -399,8 +387,7 @@ command:
         none: Con la profesión de %jobname% no vas a recibir dinero por esquilar ovejas.
       explore:
         info: '&eExplorar'
-        none: Con la profesión de %jobname% no vas a recibir dinero por explorar el
-          mundo.
+        none: Con la profesión de %jobname% no vas a recibir dinero por explorar el mundo.
       custom-kill:
         info: '&eAsesinato'
         none: Con la profesión de %jobname% no vas a recibir dinero por asesinar jugadores.
@@ -426,8 +413,7 @@ command:
       args: '[jobname]'
     error:
       alreadyin: Ya estás trabajando de %jobname%.
-      fullslots: No puedes trabajar en la profesión de %jobname%, ya que no hay puestos
-        libres.
+      fullslots: No puedes trabajar en la profesión de %jobname%, ya que no hay puestos libres.
       maxjobs: No puedes trabajar en más profesiones.
       rejoin: '&cNo te puedes volver a trabajar en esta profesión. Debes esperar [time]'
     rejoin: '&aHaz clic para unirte a este trabajo: '
@@ -438,16 +424,14 @@ command:
       info: Abandonar la profesión.
       args: '[oldplayerjob]'
     success: Has abandonado la profesión de %jobname%.
-    confirmationNeed: '&cEstás seguro de quieres abandonar el trabajo de &e [jobname]&c?
-      Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
+    confirmationNeed: '&cEstás seguro de quieres abandonar el trabajo de &e [jobname]&c? Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
   leaveall:
     help:
       info: Abandonar todas las profesiones.
     error:
       nojobs: No tienes ninguna profesión que abandonar
     success: Has abandonado todas tus profesiones.
-    confirmationNeed: '&cEstás seguro de quieres abandonar &eTODOS los trabajos&c?
-      Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
+    confirmationNeed: '&cEstás seguro de quieres abandonar &eTODOS los trabajos&c? Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
   explored:
     help:
       info: Comprobar quien ha visitado este chunk
@@ -505,16 +489,14 @@ command:
       args: '[jobname] [questname] (NombreJugador)'
     output:
       questSkipForCost: '&2Te saltaste la misión y pagaste:&e %amount%$'
-    confirmationNeed: '&cEstás seguro que deseas omitir la misión &c[questName]? Escribe
-      el comando y vuelve a confirmar dentro de &6 [tiempo] segundos!'
+    confirmationNeed: '&cEstás seguro que deseas omitir la misión &c[questName]? Escribe el comando y vuelve a confirmar dentro de &6 [tiempo] segundos!'
   quests:
     help:
       info: Ver la lista de misiones disponibles.
       args: '[playername]'
     error:
       noquests: No hay misiones.
-    toplineseparator: '&7*********************** &6[playerName] &2(&f[questsDone]&2)
-      &7***********************'
+    toplineseparator: '&7*********************** &6[playerName] &2(&f[questsDone]&2) &7***********************'
     status:
       changed: '&2El estado de la misión ha cambiado a&r %status%'
       started: '&aComenzado'
@@ -524,7 +506,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Clic para saltar la misión'
       skips: '&7Saltos de misión restantes: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nueva misión en: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nueva misión en: [time]"
   fire:
     help:
       info: Despedir al jugador del trabajo.
@@ -579,8 +565,7 @@ command:
     output:
       addedNew: '&eSe ha añadido una nueva área restringida con un bonus de &6%bonus%'
       removed: '&eSe ha eliminado el área restringida &6%name%'
-      lists: '&7%number%&f. &7%areaname% &f%worldname% &7(&a%x1%:%y1%:%z1%&7/&e%x2%:%y2%:%z2%&7)
-        &2%money% &6%points% &e%exp%'
+      lists: '&7%number%&f. &7%areaname% &f%worldname% &7(&a%x1%:%y1%:%z1%&7/&e%x2%:%y2%:%z2%&7) &2%money% &6%points% &e%exp%'
       wgLists: '&7%number%&f. WorldGuard: &7%areaname% &2%money% &6%points% &e%exp%'
       noAreas: '&eNo hay áreas restringidas guardadas'
       noAreasByLoc: '&eNo hay áreas restringidas en esta ubicación'
@@ -601,8 +586,7 @@ command:
       money: '&6dinero: %amount% '
       exp: '&eExperiencia: &%amount% '
       points: '&6puntos: %amount%'
-      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total
-        puntos:&2 %points%'
+      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total puntos:&2 %points%'
       bottomline: '&7***********************************************************'
       prev: '&e<<<<< Página anterior &2|'
       next: '&2|&e Página siguiente >>>>'
@@ -617,14 +601,12 @@ command:
       money: '&6dinero: %amount% '
       exp: '&eexp: %amount% '
       points: '&6puntos: %amount%'
-      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total
-        puntos:&2 %points%'
+      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total puntos:&2 %points%'
       bottomline: '&7**************************************************************'
       nodata: '&cDatos no encontrados'
   transfer:
     help:
-      info: Transferir el trabajo de un jugador de un trabajo antiguo a un trabajo
-        nuevo.
+      info: Transferir el trabajo de un jugador de un trabajo antiguo a un trabajo nuevo.
       args: '[playername] [oldjob] [newjob]'
     output:
       target: Has sido transferido de %oldjobname% a %newjobname%.
@@ -641,8 +623,7 @@ command:
     error:
       nojob: '&cEste jugador primero debe unirse a un trabajo.'
     output:
-      target: '&eTu exp fue cambiada por %jobname% &ey ahora tienes nivel &6%level%
-        &ey &6%exp%exp.'
+      target: '&eTu exp fue cambiada por %jobname% &ey ahora tienes nivel &6%level% &ey &6%exp%exp.'
   level:
     help:
       info: Cambia el nivel de un jugador en un trabajo.
@@ -650,8 +631,7 @@ command:
     error:
       nojob: '&cEste jugador debe unirse primero a un trabajo.'
     output:
-      target: '&eTu nivel ha sido cambiado para %jobname% &ey ahora estás en nivel
-        &6%level% &econ &6%exp%exp.'
+      target: '&eTu nivel ha sido cambiado para %jobname% &ey ahora estás en nivel &6%level% &econ &6%exp%exp.'
   demote:
     help:
       info: Desciende a un jugador X niveles en un trabajo.
@@ -728,10 +708,8 @@ message:
     broadcast: '%playername% ahora es nivel %joblevel% %jobname%.'
     nobroadcast: Ahora eres nivel %joblevel% %jobname%.
   leveldown:
-    message: '&cHas perdido&e %lostLevel%&c en tu trabajo de&e %jobname%&c! Nivel:&6
-      %joblevel%&c.'
-  cowtimer: '&eAún tienes que esperar &6%time% &esegundos para ser pagado por este
-    trabajo.'
+    message: '&cHas perdido&e %lostLevel%&c en tu trabajo de&e %jobname%&c! Nivel:&6 %joblevel%&c.'
+  cowtimer: '&eAún tienes que esperar &6%time% &esegundos para ser pagado por este trabajo.'
   blocktimer: '&eTienes que esperar &3[time] &epara ser pagado por esto!'
   taxes: '&3[amount] &eimpuestos del servidor se transfirieron a esta cuenta'
   boostStarted: '&eAcaba de empezar el boost de trabajos!'

--- a/src/main/resources/locale/messages_es.yml
+++ b/src/main/resources/locale/messages_es.yml
@@ -256,7 +256,7 @@ command:
     output:
       Level: '&7Nivel &f%joblevel% &7de &f%jobname%&7: &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2Max    &7Nivel &f%joblevel% &7de &f%jobname%'
-    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain%  $%money%'
+    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_es.yml
+++ b/src/main/resources/locale/messages_es.yml
@@ -77,9 +77,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Desde el nivel: %from%\ 
-
-        &7Hasta el nivel: %until%"
+      hoverLevelLimits: "&7Desde el nivel: %from% \n&7Hasta el nivel: %until%"
   edititembonus:
     help:
       info: Editar bonificación de impulso de item
@@ -100,10 +98,12 @@ command:
       mcmmo: ' &eBonificacion McMMO: &2%money% &6%points% &e%exp%'
       final: ' &eBonificacion final: &2%money% &6%points% &e%exp%'
       specialPrefix: '&6*'
-      finalExplanation: ' &eNo se incluye la prima de Mascota o la penalización de proximidad de spawner.'
+      finalExplanation: ' &eNo se incluye la prima de Mascota o la penalización de
+        proximidad de spawner.'
   convert:
     help:
-      info: Convierte el sistema de base de datos en otro tipo. De SQLite a MySQL o viceversa.
+      info: Convierte el sistema de base de datos en otro tipo. De SQLite a MySQL
+        o viceversa.
       args: ''
   limit:
     help:
@@ -112,13 +112,16 @@ command:
     output:
       moneytime: '&eTiempo restante hasta que el Salario vuelva a la normalidad: &2%time%'
       moneyLimit: '&eLímite de Pago: &2%current%&e/&2%total%'
-      exptime: '&eTiempo restante hasta que la Experiencia vuelva a la normalidad: &2%time%'
+      exptime: '&eTiempo restante hasta que la Experiencia vuelva a la normalidad:
+        &2%time%'
       expLimit: '&eLímite de Experiencia: &2%current%&e/&2%total%'
-      pointstime: '&eTiempo restante hasta que los Puntos vuelvan a la normalidad: &2%time%'
+      pointstime: '&eTiempo restante hasta que los Puntos vuelvan a la normalidad:
+        &2%time%'
       pointsLimit: '&eLímite de Puntos: &2%current%&e/&2%total%'
       reachedmoneylimit: '&4Has alcanzado el salario máximo permitido por minuto!'
       reachedmoneylimit2: '&ePuedes comprobar el límite con el conjuro &2/jobs limit'
-      reachedmoneylimit3: '&eEl dinero ganado ahora se reduce exponencialmente... ¡Pero aún ganas un poco!'
+      reachedmoneylimit3: '&eEl dinero ganado ahora se reduce exponencialmente...
+        ¡Pero aún ganas un poco!'
       reachedexplimit: '&4Has alcanzado el límite de Experiencia obtenida por minuto!'
       reachedexplimit2: '&ePuedes comprobar el límite con el conjuro &2/jobs limit'
       reachedpointslimit: '&4Haz alcanzado el límite de Puntos obtenidos por minuto!'
@@ -131,7 +134,8 @@ command:
     output:
       notenabled: '&eNo habilitado.'
       invalidname: '&eNombre de mundo invalido'
-      reseted: '&eLos datos de la región de exploración se han restablecido para: &2%worldname%'
+      reseted: '&eLos datos de la región de exploración se han restablecido para:
+        &2%worldname%'
   resetlimit:
     help:
       info: Reinicia los límites de pago de jugadores.
@@ -164,7 +168,8 @@ command:
     output:
       set: '&eSe ha establecido la cantidad de &6%amount% &epuntos (a &6%playername%&e)'
       add: '&Se han añadido &6%amount%&e puntos a &6%playername%&e. Total: &6%total%'
-      take: '&eEl jugador (&6%playername%&e) ha perdido &6%amount% &epuntos. Ahora tiene &6%total%'
+      take: '&eEl jugador (&6%playername%&e) ha perdido &6%amount% &epuntos. Ahora
+        tiene &6%total%'
   editjobs:
     help:
       info: Modificar la profesión actual.
@@ -183,10 +188,12 @@ command:
         newValue: '&eIntroduce el nuevo valor'
         enter: '&eIntroduce un nombre nuevo o clic '
         hand: '&6IZQUIERDO '
-        handHover: '&6Clic izquierdo para obtener información sobre el objeto de tu mano'
+        handHover: '&6Clic izquierdo para obtener información sobre el objeto de tu
+          mano'
         or: '&eo '
         look: '&6MIRALO'
-        lookHover: '&6Clic izquierdo para obtener información sobre el bloque que estás mirando'
+        lookHover: '&6Clic izquierdo para obtener información sobre el bloque que
+          estás mirando'
   editquests:
     help:
       info: Editar misiones actuales.
@@ -271,7 +278,8 @@ command:
       cantOpen: '&cNo se puede abrir esta página'
       NoPermForItem: '&cNo tienes permiso para obtener este item!'
       NoPermToBuy: '&cNo tienes permiso para comprar este item.'
-      NoJobReqForitem: '&cNo estás en la profesión necesaria (&6%jobname%&e) y no tienes el nivel (&6%joblevel%&e) necesario.'
+      NoJobReqForitem: '&cNo estás en la profesión necesaria (&6%jobname%&e) y no
+        tienes el nivel (&6%joblevel%&e) necesario.'
       NoPoints: '&cNo tienes puntos suficientes.'
       NoMoney: '&cNo tienes suficiente dinero'
       NoTotalLevel: '&cEl nivel de la profesión es demasiado bajo (%totalLevel%)&c.'
@@ -284,7 +292,8 @@ command:
       nojob: No hay profesiones guardadas.
   give:
     help:
-      info: Obtener el item a partir del nombre o la categoría. El nombre de jugador es opcional.
+      info: Obtener el item a partir del nombre o la categoría. El nombre de jugador
+        es opcional.
       args: '[playername] [jobname] [items/limiteditems] [jobitemname]'
     output:
       notonline: '&4El jugador con ese nombre no está conectado!'
@@ -293,8 +302,10 @@ command:
     help:
       title: '&2*** &ePROFESIONES&2 ***'
       info: Muestra los detalles de la profesión.
-      penalty: '&eTrabajar en esta profesión conlleva una penalización del &c[penalty]% &eporque hay muchos trabajadores.'
-      bonus: '&eTrabajar en esta profesión implica obtener una prima del &2[bonus]% &eporque hay pocos trabajadores.'
+      penalty: '&eTrabajar en esta profesión conlleva una penalización del &c[penalty]%
+        &eporque hay muchos trabajadores.'
+      bonus: '&eTrabajar en esta profesión implica obtener una prima del &2[bonus]%
+        &eporque hay pocos trabajadores.'
       args: '[jobname] [action]'
       actions: '&eAcciones validas: &f%actions%'
       max: ' - &enivel máximo:&f '
@@ -339,7 +350,8 @@ command:
         none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos.
       mmkill:
         info: '&eMMKill'
-        none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos míticos.
+        none: Con la profesión de %jobname% no vas a recibir dinero por matar monstruos
+          míticos.
       fish:
         info: '&ePescar'
         none: Con la profesión de %jobname% no vas a recibir dinero por pescar peces.
@@ -387,7 +399,8 @@ command:
         none: Con la profesión de %jobname% no vas a recibir dinero por esquilar ovejas.
       explore:
         info: '&eExplorar'
-        none: Con la profesión de %jobname% no vas a recibir dinero por explorar el mundo.
+        none: Con la profesión de %jobname% no vas a recibir dinero por explorar el
+          mundo.
       custom-kill:
         info: '&eAsesinato'
         none: Con la profesión de %jobname% no vas a recibir dinero por asesinar jugadores.
@@ -413,7 +426,8 @@ command:
       args: '[jobname]'
     error:
       alreadyin: Ya estás trabajando de %jobname%.
-      fullslots: No puedes trabajar en la profesión de %jobname%, ya que no hay puestos libres.
+      fullslots: No puedes trabajar en la profesión de %jobname%, ya que no hay puestos
+        libres.
       maxjobs: No puedes trabajar en más profesiones.
       rejoin: '&cNo te puedes volver a trabajar en esta profesión. Debes esperar [time]'
     rejoin: '&aHaz clic para unirte a este trabajo: '
@@ -424,14 +438,16 @@ command:
       info: Abandonar la profesión.
       args: '[oldplayerjob]'
     success: Has abandonado la profesión de %jobname%.
-    confirmationNeed: '&cEstás seguro de quieres abandonar el trabajo de &e [jobname]&c? Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
+    confirmationNeed: '&cEstás seguro de quieres abandonar el trabajo de &e [jobname]&c?
+      Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
   leaveall:
     help:
       info: Abandonar todas las profesiones.
     error:
       nojobs: No tienes ninguna profesión que abandonar
     success: Has abandonado todas tus profesiones.
-    confirmationNeed: '&cEstás seguro de quieres abandonar &eTODOS los trabajos&c? Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
+    confirmationNeed: '&cEstás seguro de quieres abandonar &eTODOS los trabajos&c?
+      Escribe de nuevo el comando en menos de &6 [time] segundos &cpara confirmar!'
   explored:
     help:
       info: Comprobar quien ha visitado este chunk
@@ -489,14 +505,16 @@ command:
       args: '[jobname] [questname] (NombreJugador)'
     output:
       questSkipForCost: '&2Te saltaste la misión y pagaste:&e %amount%$'
-    confirmationNeed: '&cEstás seguro que deseas omitir la misión &c[questName]? Escribe el comando y vuelve a confirmar dentro de &6 [tiempo] segundos!'
+    confirmationNeed: '&cEstás seguro que deseas omitir la misión &c[questName]? Escribe
+      el comando y vuelve a confirmar dentro de &6 [tiempo] segundos!'
   quests:
     help:
       info: Ver la lista de misiones disponibles.
       args: '[playername]'
     error:
       noquests: No hay misiones.
-    toplineseparator: '&7*********************** &6[playerName] &2(&f[questsDone]&2) &7***********************'
+    toplineseparator: '&7*********************** &6[playerName] &2(&f[questsDone]&2)
+      &7***********************'
     status:
       changed: '&2El estado de la misión ha cambiado a&r %status%'
       started: '&aComenzado'
@@ -506,11 +524,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Clic para saltar la misión'
       skips: '&7Saltos de misión restantes: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nueva misión en: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nueva misión en: [time]"
   fire:
     help:
       info: Despedir al jugador del trabajo.
@@ -565,7 +579,8 @@ command:
     output:
       addedNew: '&eSe ha añadido una nueva área restringida con un bonus de &6%bonus%'
       removed: '&eSe ha eliminado el área restringida &6%name%'
-      lists: '&7%number%&f. &7%areaname% &f%worldname% &7(&a%x1%:%y1%:%z1%&7/&e%x2%:%y2%:%z2%&7) &2%money% &6%points% &e%exp%'
+      lists: '&7%number%&f. &7%areaname% &f%worldname% &7(&a%x1%:%y1%:%z1%&7/&e%x2%:%y2%:%z2%&7)
+        &2%money% &6%points% &e%exp%'
       wgLists: '&7%number%&f. WorldGuard: &7%areaname% &2%money% &6%points% &e%exp%'
       noAreas: '&eNo hay áreas restringidas guardadas'
       noAreasByLoc: '&eNo hay áreas restringidas en esta ubicación'
@@ -586,7 +601,8 @@ command:
       money: '&6dinero: %amount% '
       exp: '&eExperiencia: &%amount% '
       points: '&6puntos: %amount%'
-      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total puntos:&2 %points%'
+      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total
+        puntos:&2 %points%'
       bottomline: '&7***********************************************************'
       prev: '&e<<<<< Página anterior &2|'
       next: '&2|&e Página siguiente >>>>'
@@ -601,12 +617,14 @@ command:
       money: '&6dinero: %amount% '
       exp: '&eexp: %amount% '
       points: '&6puntos: %amount%'
-      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total puntos:&2 %points%'
+      totalIncomes: '    &6Dinero total:&2 %money%&6, Exp total:&2 %exp%&6, Total
+        puntos:&2 %points%'
       bottomline: '&7**************************************************************'
       nodata: '&cDatos no encontrados'
   transfer:
     help:
-      info: Transferir el trabajo de un jugador de un trabajo antiguo a un trabajo nuevo.
+      info: Transferir el trabajo de un jugador de un trabajo antiguo a un trabajo
+        nuevo.
       args: '[playername] [oldjob] [newjob]'
     output:
       target: Has sido transferido de %oldjobname% a %newjobname%.
@@ -623,7 +641,8 @@ command:
     error:
       nojob: '&cEste jugador primero debe unirse a un trabajo.'
     output:
-      target: '&eTu exp fue cambiada por %jobname% &ey ahora tienes nivel &6%level% &ey &6%exp%exp.'
+      target: '&eTu exp fue cambiada por %jobname% &ey ahora tienes nivel &6%level%
+        &ey &6%exp%exp.'
   level:
     help:
       info: Cambia el nivel de un jugador en un trabajo.
@@ -631,7 +650,8 @@ command:
     error:
       nojob: '&cEste jugador debe unirse primero a un trabajo.'
     output:
-      target: '&eTu nivel ha sido cambiado para %jobname% &ey ahora estás en nivel &6%level% &econ &6%exp%exp.'
+      target: '&eTu nivel ha sido cambiado para %jobname% &ey ahora estás en nivel
+        &6%level% &econ &6%exp%exp.'
   demote:
     help:
       info: Desciende a un jugador X niveles en un trabajo.
@@ -708,8 +728,10 @@ message:
     broadcast: '%playername% ahora es nivel %joblevel% %jobname%.'
     nobroadcast: Ahora eres nivel %joblevel% %jobname%.
   leveldown:
-    message: '&cHas perdido&e %lostLevel%&c en tu trabajo de&e %jobname%&c! Nivel:&6 %joblevel%&c.'
-  cowtimer: '&eAún tienes que esperar &6%time% &esegundos para ser pagado por este trabajo.'
+    message: '&cHas perdido&e %lostLevel%&c en tu trabajo de&e %jobname%&c! Nivel:&6
+      %joblevel%&c.'
+  cowtimer: '&eAún tienes que esperar &6%time% &esegundos para ser pagado por este
+    trabajo.'
   blocktimer: '&eTienes que esperar &3[time] &epara ser pagado por esto!'
   taxes: '&3[amount] &eimpuestos del servidor se transfirieron a esta cuenta'
   boostStarted: '&eAcaba de empezar el boost de trabajos!'

--- a/src/main/resources/locale/messages_es.yml
+++ b/src/main/resources/locale/messages_es.yml
@@ -256,7 +256,7 @@ command:
     output:
       Level: '&7Nivel &f%joblevel% &7de &f%jobname%&7: &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2Max    &7Nivel &f%joblevel% &7de &f%jobname%'
-    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain% $%money%'
+    bossBarOutput: 'Nvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% Exp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_fr.yml
+++ b/src/main/resources/locale/messages_fr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% pour %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cNiveau max   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_fr.yml
+++ b/src/main/resources/locale/messages_fr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% pour %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cNiveau max   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_fr.yml
+++ b/src/main/resources/locale/messages_fr.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Du niveau: %from%
-
-        &7Au niveau: %until%"
+      hoverLevelLimits: "&7Du niveau: %from%\n&7Au niveau: %until%"
   edititembonus:
     help:
       info: Éditer l'objet bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Cliquez pour passer cette quête'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nouvelle quête dans : [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nouvelle quête dans : [time]"
   fire:
     help:
       info: Renvoie le joueur de son métier.

--- a/src/main/resources/locale/messages_fr.yml
+++ b/src/main/resources/locale/messages_fr.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Du niveau: %from%\n&7Au niveau: %until%"
+      hoverLevelLimits: "&7Du niveau: %from%
+
+        &7Au niveau: %until%"
   edititembonus:
     help:
       info: Éditer l'objet bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Niveau %joblevel% pour %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cNiveau max   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Cliquez pour passer cette quête'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nouvelle quête dans : [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nouvelle quête dans : [time]"
   fire:
     help:
       info: Renvoie le joueur de son métier.

--- a/src/main/resources/locale/messages_fr.yml
+++ b/src/main/resources/locale/messages_fr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% pour %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cNiveau max   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_hu.yml
+++ b/src/main/resources/locale/messages_hu.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Szinttől: %from%\n&7Szintig: %until%"
+      hoverLevelLimits: "&7Szinttől: %from%
+
+        &7Szintig: %until%"
   edititembonus:
     help:
       info: Tárgybónusz szerkesztése.
@@ -259,7 +261,7 @@ command:
     output:
       message: ' lvl%joblevel% %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax szint   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Kattints, hogy hagyja ki ezt a küldetést'
       skips: '&7Maradt ugrások: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Következő küldetés: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Következő küldetés: [time]"
   fire:
     help:
       info: Játékos kirúgása a munkából.

--- a/src/main/resources/locale/messages_hu.yml
+++ b/src/main/resources/locale/messages_hu.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: ' lvl%joblevel% %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax szint   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_hu.yml
+++ b/src/main/resources/locale/messages_hu.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: ' lvl%joblevel% %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax szint   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_hu.yml
+++ b/src/main/resources/locale/messages_hu.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: ' lvl%joblevel% %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax szint   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_hu.yml
+++ b/src/main/resources/locale/messages_hu.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Szinttől: %from%
-
-        &7Szintig: %until%"
+      hoverLevelLimits: "&7Szinttől: %from%\n&7Szintig: %until%"
   edititembonus:
     help:
       info: Tárgybónusz szerkesztése.
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Kattints, hogy hagyja ki ezt a küldetést'
       skips: '&7Maradt ugrások: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Következő küldetés: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Következő küldetés: [time]"
   fire:
     help:
       info: Játékos kirúgása a munkából.

--- a/src/main/resources/locale/messages_it_IT.yml
+++ b/src/main/resources/locale/messages_it_IT.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Da livello: %from%
-
-        &7Fino al livello: %until%"
+      hoverLevelLimits: "&7Da livello: %from%\n&7Fino al livello: %until%"
   edititembonus:
     help:
       info: Modifica bonus potenziamento oggetto
@@ -286,13 +284,13 @@ command:
       Paid: '&eHai pagato &6%amount% &eper questo articolo '
   archive:
     help:
-      info: Mostra tutti i lavori salvati nell'archivio dall'utente.
+      info: Mostra tutti i lavori salvati nell'archivio dall'utente. 
       args: '[playername]'
     error:
       nojob: Non ci sono lavori salvati.
   give:
     help:
-      info: Fornisce l'elemento in base al nome del lavoro e al nome della categoria dell'elemento. Il nome del giocatore è facoltativo
+      info: Fornisce l'elemento in base al nome del lavoro e al nome della categoria dell'elemento. Il nome del giocatore è facoltativo 
       args: '[playername] [jobname] [items/limiteditems] [jobitemname]'
     output:
       notonline: '&4Il giocatore con quel nome non è online! '
@@ -300,7 +298,7 @@ command:
   info:
     help:
       title: '&2*** &eLavori&2 ***'
-      info: Mostra quanto viene pagato ogni lavoro e per cosa.
+      info: Mostra quanto viene pagato ogni lavoro e per cosa. 
       penalty: '&eQuesto lavoro ha una penalità del &c[penalty]% &eperché ci sono troppi giocatori che ci lavorano. '
       bonus: '&eQuesto lavoro ha un bonus del &2[bonus]% &eperché non ci sono abbastanza giocatori che ci lavorano. '
       args: '[jobname] [action]'
@@ -407,7 +405,7 @@ command:
       args: '[jobfullname]'
     error:
       alreadyin: Sei già nel lavoro %jobname%.
-      fullslots: Non puoi unirti al lavoro %jobname%, non ci sono spazi disponibili.
+      fullslots: Non puoi unirti al lavoro %jobname%, non ci sono spazi disponibili. 
       maxjobs: Hai già aderito a troppi lavori.
       rejoin: '&cImpossibile partecipare a questo lavoro. Aspetta [time]'
     rejoin: '&aFai clic per unirti di nuovo a questo lavoro: '
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Fai clic per saltare questa missione'
       skips: '&7Salta sinistra: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nuova missione in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nuova missione in: [time]"
   fire:
     help:
       info: Licenzia il giocatore dal lavoro.

--- a/src/main/resources/locale/messages_it_IT.yml
+++ b/src/main/resources/locale/messages_it_IT.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Livello %joblevel% per %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cLivello Max   -   %jobname%'
-    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_it_IT.yml
+++ b/src/main/resources/locale/messages_it_IT.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Da livello: %from%\n&7Fino al livello: %until%"
+      hoverLevelLimits: "&7Da livello: %from%
+
+        &7Fino al livello: %until%"
   edititembonus:
     help:
       info: Modifica bonus potenziamento oggetto
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Livello %joblevel% per %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cLivello Max   -   %jobname%'
-    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -284,13 +286,13 @@ command:
       Paid: '&eHai pagato &6%amount% &eper questo articolo '
   archive:
     help:
-      info: Mostra tutti i lavori salvati nell'archivio dall'utente. 
+      info: Mostra tutti i lavori salvati nell'archivio dall'utente.
       args: '[playername]'
     error:
       nojob: Non ci sono lavori salvati.
   give:
     help:
-      info: Fornisce l'elemento in base al nome del lavoro e al nome della categoria dell'elemento. Il nome del giocatore è facoltativo 
+      info: Fornisce l'elemento in base al nome del lavoro e al nome della categoria dell'elemento. Il nome del giocatore è facoltativo
       args: '[playername] [jobname] [items/limiteditems] [jobitemname]'
     output:
       notonline: '&4Il giocatore con quel nome non è online! '
@@ -298,7 +300,7 @@ command:
   info:
     help:
       title: '&2*** &eLavori&2 ***'
-      info: Mostra quanto viene pagato ogni lavoro e per cosa. 
+      info: Mostra quanto viene pagato ogni lavoro e per cosa.
       penalty: '&eQuesto lavoro ha una penalità del &c[penalty]% &eperché ci sono troppi giocatori che ci lavorano. '
       bonus: '&eQuesto lavoro ha un bonus del &2[bonus]% &eperché non ci sono abbastanza giocatori che ci lavorano. '
       args: '[jobname] [action]'
@@ -405,7 +407,7 @@ command:
       args: '[jobfullname]'
     error:
       alreadyin: Sei già nel lavoro %jobname%.
-      fullslots: Non puoi unirti al lavoro %jobname%, non ci sono spazi disponibili. 
+      fullslots: Non puoi unirti al lavoro %jobname%, non ci sono spazi disponibili.
       maxjobs: Hai già aderito a troppi lavori.
       rejoin: '&cImpossibile partecipare a questo lavoro. Aspetta [time]'
     rejoin: '&aFai clic per unirti di nuovo a questo lavoro: '
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Fai clic per saltare questa missione'
       skips: '&7Salta sinistra: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nuova missione in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nuova missione in: [time]"
   fire:
     help:
       info: Licenzia il giocatore dal lavoro.

--- a/src/main/resources/locale/messages_it_IT.yml
+++ b/src/main/resources/locale/messages_it_IT.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Livello %joblevel% per %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cLivello Max   -   %jobname%'
-    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_it_IT.yml
+++ b/src/main/resources/locale/messages_it_IT.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Livello %joblevel% per %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cLivello Max   -   %jobname%'
-    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Livello %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -267,7 +267,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -267,7 +267,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from%\ 
+
+        &7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -267,7 +269,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -494,7 +496,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7New quest in: [time]"
   fire:
     help:
       info: '[player]に[職業名]を強制的に離職させます'

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from%\ 
-
-        &7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -496,11 +494,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7New quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
   fire:
     help:
       info: '[player]に[職業名]を強制的に離職させます'

--- a/src/main/resources/locale/messages_ja.yml
+++ b/src/main/resources/locale/messages_ja.yml
@@ -267,7 +267,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ko.yml
+++ b/src/main/resources/locale/messages_ko.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ko.yml
+++ b/src/main/resources/locale/messages_ko.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ko.yml
+++ b/src/main/resources/locale/messages_ko.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ko.yml
+++ b/src/main/resources/locale/messages_ko.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from%\ 
-
-        &7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7New quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_ko.yml
+++ b/src/main/resources/locale/messages_ko.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from%\ 
+
+        &7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_nl_NL.yml
+++ b/src/main/resources/locale/messages_nl_NL.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% voor %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax niveau   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_nl_NL.yml
+++ b/src/main/resources/locale/messages_nl_NL.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% voor %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax niveau   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_nl_NL.yml
+++ b/src/main/resources/locale/messages_nl_NL.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Niveau %joblevel% voor %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax niveau   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_nl_NL.yml
+++ b/src/main/resources/locale/messages_nl_NL.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Vanaf niveau: %from% \n&7Tot niveau: %until%"
+      hoverLevelLimits: "&7Vanaf niveau: %from%\ 
+
+        &7Tot niveau: %until%"
   edititembonus:
     help:
       info: Verander de itembonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Niveau %joblevel% voor %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax niveau   -   %jobname%'
-    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Niveau %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klik op deze quest over te slaan'
       skips: '&7hoeveelheid overslaan: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nieuwe quest na: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nieuwe quest na: [time]"
   fire:
     help:
       info: Ontsla de speler van de baan.

--- a/src/main/resources/locale/messages_nl_NL.yml
+++ b/src/main/resources/locale/messages_nl_NL.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Vanaf niveau: %from%\ 
-
-        &7Tot niveau: %until%"
+      hoverLevelLimits: "&7Vanaf niveau: %from% \n&7Tot niveau: %until%"
   edititembonus:
     help:
       info: Verander de itembonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klik op deze quest over te slaan'
       skips: '&7hoeveelheid overslaan: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nieuwe quest na: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nieuwe quest na: [time]"
   fire:
     help:
       info: Ontsla de speler van de baan.

--- a/src/main/resources/locale/messages_no_NO.yml
+++ b/src/main/resources/locale/messages_no_NO.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Fra nivå: %from% \n&7Til nivå: %until%"
+      hoverLevelLimits: "&7Fra nivå: %from%\ 
+
+        &7Til nivå: %until%"
   edititembonus:
     help:
       info: Rediger gjenstandsboost-bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klikk for å hoppe over denne oppgaven'
       skips: '&7Hvor mange ganger du kan hoppe over igjen: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nytt oppdrag igjen: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nytt oppdrag igjen: [time]"
   fire:
     help:
       info: Fjern spilleren fra jobben.

--- a/src/main/resources/locale/messages_no_NO.yml
+++ b/src/main/resources/locale/messages_no_NO.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_no_NO.yml
+++ b/src/main/resources/locale/messages_no_NO.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Fra nivå: %from%\ 
-
-        &7Til nivå: %until%"
+      hoverLevelLimits: "&7Fra nivå: %from% \n&7Til nivå: %until%"
   edititembonus:
     help:
       info: Rediger gjenstandsboost-bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Klikk for å hoppe over denne oppgaven'
       skips: '&7Hvor mange ganger du kan hoppe over igjen: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nytt oppdrag igjen: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nytt oppdrag igjen: [time]"
   fire:
     help:
       info: Fjern spilleren fra jobben.

--- a/src/main/resources/locale/messages_no_NO.yml
+++ b/src/main/resources/locale/messages_no_NO.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_no_NO.yml
+++ b/src/main/resources/locale/messages_no_NO.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_pl.yml
+++ b/src/main/resources/locale/messages_pl.yml
@@ -268,7 +268,7 @@ command:
     output:
       message: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP'
       max-level: '     &cMaks. poziom   -   %jobname%'
-    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     bar1: '&e▏'
     bar2: '&2▏'

--- a/src/main/resources/locale/messages_pl.yml
+++ b/src/main/resources/locale/messages_pl.yml
@@ -268,7 +268,7 @@ command:
     output:
       message: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP'
       max-level: '     &cMaks. poziom   -   %jobname%'
-    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
+    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
     bar1: '&e▏'
     bar2: '&2▏'

--- a/src/main/resources/locale/messages_pl.yml
+++ b/src/main/resources/locale/messages_pl.yml
@@ -108,7 +108,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Z levelu: %from% \n&7Do levelu: %until%"
+      hoverLevelLimits: "&7Z levelu: %from%\ 
+
+        &7Do levelu: %until%"
   edititembonus:
     help:
       info: Edytuj boost bonusowego przedmiotu
@@ -268,7 +270,7 @@ command:
     output:
       message: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP'
       max-level: '     &cMaks. poziom   -   %jobname%'
-    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%'
+    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     bar1: '&e▏'
     bar2: '&2▏'
@@ -498,7 +500,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Kliknij aby pominąć to zadanie'
       skips: '&7Pozostałe pominięcia: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nowe zadanie za: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nowe zadanie za: [time]"
   fire:
     help:
       info: Zwolnij gracza z pracy.

--- a/src/main/resources/locale/messages_pl.yml
+++ b/src/main/resources/locale/messages_pl.yml
@@ -268,7 +268,7 @@ command:
     output:
       message: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP'
       max-level: '     &cMaks. poziom   -   %jobname%'
-    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain%  $%money%'
+    bossBarOutput: 'Poziom %joblevel% %jobname%: %jobxp%/%jobmaxxp% XP%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     bar1: '&e▏'
     bar2: '&2▏'

--- a/src/main/resources/locale/messages_pl.yml
+++ b/src/main/resources/locale/messages_pl.yml
@@ -108,9 +108,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Z levelu: %from%\ 
-
-        &7Do levelu: %until%"
+      hoverLevelLimits: "&7Z levelu: %from% \n&7Do levelu: %until%"
   edititembonus:
     help:
       info: Edytuj boost bonusowego przedmiotu
@@ -500,11 +498,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Kliknij aby pominąć to zadanie'
       skips: '&7Pozostałe pominięcia: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nowe zadanie za: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nowe zadanie za: [time]"
   fire:
     help:
       info: Zwolnij gracza z pracy.

--- a/src/main/resources/locale/messages_pt-BR.yml
+++ b/src/main/resources/locale/messages_pt-BR.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_pt-BR.yml
+++ b/src/main/resources/locale/messages_pt-BR.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Do nível: %from%\ 
-
-        &7Até o nível: %until%"
+      hoverLevelLimits: "&7Do nível: %from% \n&7Até o nível: %until%"
   edititembonus:
     help:
       info: Editar bônus de aumento de item
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Clique para pular esta missão'
       skips: '&7Pulos restantes: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Nova missão em: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Nova missão em: [time]"
   fire:
     help:
       info: Demitir o jogador de uma profissão.

--- a/src/main/resources/locale/messages_pt-BR.yml
+++ b/src/main/resources/locale/messages_pt-BR.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_pt-BR.yml
+++ b/src/main/resources/locale/messages_pt-BR.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Do nível: %from% \n&7Até o nível: %until%"
+      hoverLevelLimits: "&7Do nível: %from%\ 
+
+        &7Até o nível: %until%"
   edititembonus:
     help:
       info: Editar bônus de aumento de item
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Clique para pular esta missão'
       skips: '&7Pulos restantes: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Nova missão em: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Nova missão em: [time]"
   fire:
     help:
       info: Demitir o jogador de uma profissão.

--- a/src/main/resources/locale/messages_pt-BR.yml
+++ b/src/main/resources/locale/messages_pt-BR.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ro.yml
+++ b/src/main/resources/locale/messages_ro.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7De la nivelul: %from% \n&7Până la nivelul: %until%"
+      hoverLevelLimits: "&7De la nivelul: %from%\ 
+
+        &7Până la nivelul: %until%"
   edititembonus:
     help:
       info: Editează majorarea itemului bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Nivel %joblevel% pentru %jobname%: %jobxp%/%jobmaxxp% experiență'
       max-level: '     &cNivel maxim   -   %jobname%'
-    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain%'
+    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Apasă pentru a trece peste această misiune'
       skips: '&2Numar rămas de "treceri peste": &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Misiune nouă în: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Misiune nouă în: [time]"
   fire:
     help:
       info: Concediază jucătorul de la acest job.

--- a/src/main/resources/locale/messages_ro.yml
+++ b/src/main/resources/locale/messages_ro.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Nivel %joblevel% pentru %jobname%: %jobxp%/%jobmaxxp% experiență'
       max-level: '     &cNivel maxim   -   %jobname%'
-    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain%  $%money%'
+    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ro.yml
+++ b/src/main/resources/locale/messages_ro.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Nivel %joblevel% pentru %jobname%: %jobxp%/%jobmaxxp% experiență'
       max-level: '     &cNivel maxim   -   %jobname%'
-    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain%'
+    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ro.yml
+++ b/src/main/resources/locale/messages_ro.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Nivel %joblevel% pentru %jobname%: %jobxp%/%jobmaxxp% experiență'
       max-level: '     &cNivel maxim   -   %jobname%'
-    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain% $%money%'
+    bossBarOutput: 'Nivel %joblevel% %jobname%: %jobxp%/%jobmaxxp% experiență%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ro.yml
+++ b/src/main/resources/locale/messages_ro.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7De la nivelul: %from%\ 
-
-        &7Până la nivelul: %until%"
+      hoverLevelLimits: "&7De la nivelul: %from% \n&7Până la nivelul: %until%"
   edititembonus:
     help:
       info: Editează majorarea itemului bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Apasă pentru a trece peste această misiune'
       skips: '&2Numar rămas de "treceri peste": &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Misiune nouă în: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Misiune nouă în: [time]"
   fire:
     help:
       info: Concediază jucătorul de la acest job.

--- a/src/main/resources/locale/messages_ru.yml
+++ b/src/main/resources/locale/messages_ru.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7С уровня: %from%\ 
-
-        &7До уровня: %until%"
+      hoverLevelLimits: "&7С уровня: %from% \n&7До уровня: %until%"
   edititembonus:
     help:
       info: Редактировать бонусы работ.
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Нажмите, чтобы пропустить этот квест'
       skips: '&7Осталось пропусков: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Новый квест через: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Новый квест через: [time]"
   fire:
     help:
       info: Уволить игрока с работы.

--- a/src/main/resources/locale/messages_ru.yml
+++ b/src/main/resources/locale/messages_ru.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Уровень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% оп.'
       max-level: '     &cМакс. уровень   -   %jobname%'
-    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain% $%money%'
+    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ru.yml
+++ b/src/main/resources/locale/messages_ru.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Уровень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% оп.'
       max-level: '     &cМакс. уровень   -   %jobname%'
-    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain%'
+    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_ru.yml
+++ b/src/main/resources/locale/messages_ru.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7С уровня: %from% \n&7До уровня: %until%"
+      hoverLevelLimits: "&7С уровня: %from%\ 
+
+        &7До уровня: %until%"
   edititembonus:
     help:
       info: Редактировать бонусы работ.
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Уровень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% оп.'
       max-level: '     &cМакс. уровень   -   %jobname%'
-    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain%'
+    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Нажмите, чтобы пропустить этот квест'
       skips: '&7Осталось пропусков: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Новый квест через: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Новый квест через: [time]"
   fire:
     help:
       info: Уволить игрока с работы.

--- a/src/main/resources/locale/messages_ru.yml
+++ b/src/main/resources/locale/messages_ru.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Уровень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% оп.'
       max-level: '     &cМакс. уровень   -   %jobname%'
-    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain%  $%money%'
+    bossBarOutput: 'Ур. %joblevel% %jobname%: %jobxp%/%jobmaxxp% оп.%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_sv-SE.yml
+++ b/src/main/resources/locale/messages_sv-SE.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_sv-SE.yml
+++ b/src/main/resources/locale/messages_sv-SE.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_sv-SE.yml
+++ b/src/main/resources/locale/messages_sv-SE.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_sv-SE.yml
+++ b/src/main/resources/locale/messages_sv-SE.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Från level: %from% \n&7Till level: %until%"
+      hoverLevelLimits: "&7Från level: %from%\ 
+
+        &7Till level: %until%"
   edititembonus:
     help:
       info: Ändra föremåls boost bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Lvl %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_sv-SE.yml
+++ b/src/main/resources/locale/messages_sv-SE.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7Från level: %from%\ 
-
-        &7Till level: %until%"
+      hoverLevelLimits: "&7Från level: %from% \n&7Till level: %until%"
   edititembonus:
     help:
       info: Ändra föremåls boost bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7New quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
   fire:
     help:
       info: Fire the player from the job.

--- a/src/main/resources/locale/messages_tr.yml
+++ b/src/main/resources/locale/messages_tr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMaks Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_tr.yml
+++ b/src/main/resources/locale/messages_tr.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from%\ 
-
-        &7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7New quest in: [time]"
+      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
   fire:
     help:
       info: Oyuncuyu mesleğinden eder.

--- a/src/main/resources/locale/messages_tr.yml
+++ b/src/main/resources/locale/messages_tr.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7From level: %from% \n&7Until level: %until%"
+      hoverLevelLimits: "&7From level: %from%\ 
+
+        &7Until level: %until%"
   edititembonus:
     help:
       info: Edit item boost bonus
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMaks Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Click to skip this quest'
       skips: '&7Left skips: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7New quest in: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7New quest in: [time]"
   fire:
     help:
       info: Oyuncuyu mesleğinden eder.

--- a/src/main/resources/locale/messages_tr.yml
+++ b/src/main/resources/locale/messages_tr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMaks Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_tr.yml
+++ b/src/main/resources/locale/messages_tr.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMaks Level   -   %jobname%'
-    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%'
+    bossBarOutput: 'Level %joblevel% %jobname%: %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_uk.yml
+++ b/src/main/resources/locale/messages_uk.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Рівень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% дос.'
       max-level: '     &cМакс. рівень   -   %jobname%'
-    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain% $%money%'
+    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_uk.yml
+++ b/src/main/resources/locale/messages_uk.yml
@@ -107,9 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7С рівня: %from%\ 
-
-        &7До рівня: %until%"
+      hoverLevelLimits: "&7С рівня: %from% \n&7До рівня: %until%"
   edititembonus:
     help:
       info: Редагування бонусів робіт.
@@ -488,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Натисніть, щоб пропустити цей квест'
       skips: '&7Залишилось пропусків: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7Новий квест через: [time]"
+      hover: "&f[jobName] \n[desc] \n&7Новий квест через: [time]"
   fire:
     help:
       info: Звільнити гравця із роботи.

--- a/src/main/resources/locale/messages_uk.yml
+++ b/src/main/resources/locale/messages_uk.yml
@@ -107,7 +107,9 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7С рівня: %from% \n&7До рівня: %until%"
+      hoverLevelLimits: "&7С рівня: %from%\ 
+
+        &7До рівня: %until%"
   edititembonus:
     help:
       info: Редагування бонусів робіт.
@@ -259,7 +261,7 @@ command:
     output:
       message: 'Рівень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% дос.'
       max-level: '     &cМакс. рівень   -   %jobname%'
-    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain%'
+    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +488,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7Натисніть, щоб пропустити цей квест'
       skips: '&7Залишилось пропусків: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7Новий квест через: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7Новий квест через: [time]"
   fire:
     help:
       info: Звільнити гравця із роботи.

--- a/src/main/resources/locale/messages_uk.yml
+++ b/src/main/resources/locale/messages_uk.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Рівень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% дос.'
       max-level: '     &cМакс. рівень   -   %jobname%'
-    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain%  $%money%'
+    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_uk.yml
+++ b/src/main/resources/locale/messages_uk.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Рівень %joblevel% для %jobname%: %jobxp%/%jobmaxxp% дос.'
       max-level: '     &cМакс. рівень   -   %jobname%'
-    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain%'
+    bossBarOutput: 'Рів. %joblevel% %jobname%: %jobxp%/%jobmaxxp% дос.%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_zhcn.yml
+++ b/src/main/resources/locale/messages_zhcn.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain%'
+    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_zhcn.yml
+++ b/src/main/resources/locale/messages_zhcn.yml
@@ -107,7 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7从经验等级: %from% \n&7直到经验等级: %until%"
+      hoverLevelLimits: "&7从经验等级: %from%\ \n&7直到经验等级: %until%"
   edititembonus:
     help:
       info: 更改物品加成
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain%'
+    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:
@@ -486,7 +486,11 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7点击跳过该任务'
       skips: '&7剩余跳过次数: &f[skips]'
-      hover: "&f[jobName] \n[desc] \n&7下个新任务: [time]"
+      hover: "&f[jobName]\ 
+
+        [desc]\ 
+
+        &7下个新任务: [time]"
   fire:
     help:
       info: 将玩家从指定职业开除.

--- a/src/main/resources/locale/messages_zhcn.yml
+++ b/src/main/resources/locale/messages_zhcn.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain% $%money%'
+    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_zhcn.yml
+++ b/src/main/resources/locale/messages_zhcn.yml
@@ -107,7 +107,7 @@ command:
       list: '&e[jobname]: %money% %points% %exp%'
       notAplyingList: '&7[jobname]: %money% %points% %exp%'
       hover: '&7%itemtype%'
-      hoverLevelLimits: "&7从经验等级: %from%\ \n&7直到经验等级: %until%"
+      hoverLevelLimits: "&7从经验等级: %from% \n&7直到经验等级: %until%"
   edititembonus:
     help:
       info: 更改物品加成
@@ -486,11 +486,7 @@ command:
       questLine: '[progress] &7[questName] &f[done]&7/&8[required]'
       skip: '&7点击跳过该任务'
       skips: '&7剩余跳过次数: &f[skips]'
-      hover: "&f[jobName]\ 
-
-        [desc]\ 
-
-        &7下个新任务: [time]"
+      hover: "&f[jobName] \n[desc] \n&7下个新任务: [time]"
   fire:
     help:
       info: 将玩家从指定职业开除.

--- a/src/main/resources/locale/messages_zhcn.yml
+++ b/src/main/resources/locale/messages_zhcn.yml
@@ -259,7 +259,7 @@ command:
     output:
       message: 'Level %joblevel% for %jobname%: %jobxp%/%jobmaxxp% xp'
       max-level: '     &cMax level   -   %jobname%'
-    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain%  $%money%'
+    bossBarOutput: '等级 %joblevel% %jobname%: %jobxp%/%jobmaxxp% 经验值%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
   shop:
     help:

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% %money%
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% $%money%
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain%  $%money%'
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain%
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain%  $%money%'
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain%
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% %money%
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% $%money%
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain%
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'

--- a/src/main/resources/locale/messages_zhtw.yml
+++ b/src/main/resources/locale/messages_zhtw.yml
@@ -246,7 +246,7 @@ command:
     output:
       Level: '&7職業 &f%jobname% &7等級 &f%joblevel%&7： &f%jobxp%&7/&f%jobmaxxp%&7xp'
       maxLevel: '    &2最高    &7等級 &f%joblevel% &7於 &f%jobname%'
-    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% $%money%'
+    bossBarOutput: 等級 %joblevel% %jobname%： %jobxp%/%jobmaxxp% xp%gain% $%money%
     bossBarGain: ' &7(&f%gain%&7)'
     barEmpty: '&7▏'
     barFull: '&2▏'


### PR DESCRIPTION
### Description:
This PR introduces the **`%money%`** placeholder for the BossBar output, bringing its functionality closer to what is **already available and well-handled in the ActionBar**. Additionally, this PR fixes an edge case where the BossBar would not display at all if an action yielded only money but no experience (`expGain == 0`).

### Changes Made:
* **`JobProgression.java`**: Added a `lastMoney` variable (with getters and setters) to temporarily cache the money earned from an action before the BossBar updates, functioning identically to the existing `lastExperience` variable.
* **`Jobs.java`**: Updated the `action()` and `perform()` methods so that `prog.setLastMoney()` aggregates the money earned before firing the `JobsInstancePaymentEvent` and the level-up checks.
* **`BossBarManager.java`**: 
  * Updated `ShowJobProgression(player)` to check `if (oneJob.getLastExperience() != 0 || oneJob.getLastMoney() != 0)`. This ensures the BossBar still triggers for actions that only reward money and no XP.
  * Replaced the `%money%` placeholder in the `command.stats.bossBarOutput` message.
* **`LanguageManager.java` & Locale files**: Added the `%money%` placeholder to the `bossBarOutput` default string in `LanguageManager.java` and updated all existing `messages_*.yml` translation files to include it by default.

### Use Case:
Many server owners prefer to disable the ActionBar payment messages to avoid screen clutter and centralize all progression tracking (XP and Money) in the BossBar. Until now, there was no way to display the money earned directly on the BossBar.

### Testing:
- [x] Verified that `%money%` correctly parses and displays the formatted amount.
- [x] Verified that `%money%` is replaced with an empty string when the action yields no money.
- [x] Verified that actions giving 0 XP but >0 Money successfully trigger the BossBar.
- [x] Compiled without errors and tested in-game.