### PR TITLE
Fix typo in JLC enum: command_limi_output_moneyLimit causing /jobs limit to not display money limit

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/config/JLC.java
+++ b/src/main/java/com/gamingmesh/jobs/config/JLC.java
@@ -42,7 +42,7 @@ public enum JLC {
     command_limit_help_info("Shows payment limits for jobs"),
     command_limit_help_args("[playername]"),
     command_limit_output_moneytime("{gcp}Time left until money limit resets: {gcs}[time]"),
-    command_limi_output_moneyLimit("{gcp}Money limit: {gcs}[current]{gcp}/{gcs}[total]"),
+    command_limit_output_moneyLimit("{gcp}Money limit: {gcs}[current]{gcp}/{gcs}[total]"),
     command_limit_output_exptime("{gcp}Time left until Exp limit resets: {gcs}[time]"),
     command_limit_output_expLimit("{gcp}Exp limit: {gcs}[current]{gcp}/{gcs}[total]"),
     command_limit_output_pointstime("{gcp}Time left until Point limit resets: {gcs}[time]"),


### PR DESCRIPTION
## Bug description

Since commit `6e6423c` (_"Few of the locale lines got moved to ENUM"_), the `/jobs limit` command no longer displays the money limit line to the player.

### Root cause

In `JLC.java`, the enum constant for the money limit message has a typo: `limi` instead of `limit`.

```java
// Line 45 – BEFORE (broken)
command_limi_output_moneyLimit("{gcp}Money limit: {gcs}[current]{gcp}/{gcs}[total]"),

// All surrounding constants use the correct prefix:
command_limit_output_moneytime(...)
command_limit_output_exptime(...)
command_limit_output_expLimit(...)
```

`JLC#getPath()` converts underscores to dots to build the YAML key path:

```java
public String getPath() {
    return this.name().replace("_", ".");
}
```

So `command_limi_output_moneyLimit` resolves to `command.limi.output.moneyLimit` — a path that never matches what `limit.java` looks up.

### Effect chain

1. The locale file receives the key at `command.limi.output.moneyLimit` (wrong section `limi:`)
2. The `/jobs limit` command builds its lookup dynamically:
   ```java
   Language.sendMessage(sender, "command.limit.output." + typeName + "Limit", ...)
   // → "command.limit.output.moneyLimit"
   ```
3. `Language#getMessage` finds no value at `command.limit.output.moneyLimit`, returns an empty string
4. `Language#sendMessage` silently skips empty messages → **nothing is displayed**

Users also observe that in their locale file, the `moneyLimit` key appears under a `limi:` section instead of `limit:`.

## Fix

One character change in `JLC.java` (line 45):

```java
// AFTER (fixed)
command_limit_output_moneyLimit("{gcp}Money limit: {gcs}[current]{gcp}/{gcs}[total]"),
```

This restores the correct YAML path `command.limit.output.moneyLimit`, which matches the dynamic lookup in `limit.java`.
