### PR TITLE
EvenMoreFish Support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,13 @@
 			<version>1.5.40</version>
 			<scope>provided</scope>
 		</dependency>
+		<!-- EvenMoreFish -->
+		<dependency>
+			<groupId>com.oheers.evenmorefish</groupId>
+			<artifactId>even-more-fish-api</artifactId>
+			<version>2.3.6</version>
+			<scope>provided</scope>
+		</dependency>
 	</dependencies>
 	<repositories>
 		<repository>
@@ -250,6 +257,11 @@
 		<repository>
 			<id>rosewood-repo</id>
 			<url>https://repo.rosewooddev.io/repository/public/</url>
+		</repository>
+		<!-- EvenMoreFish -->
+		<repository>
+			<id>evenmorefish-repo</id>
+			<url>https://repo.codemc.io/repository/EvenMoreFish/</url>
 		</repository>
 		<!-- MyPet -->
 		<!--		<repository>-->

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -896,10 +896,9 @@ public final class Jobs extends JavaPlugin {
 
         pm.registerEvents(new JobsChatEvent(getInstance()), getInstance());
 
-        JobsHook.PyroFishingPro.registerListener();
-        JobsHook.mcMMO.registerListener();
-        JobsHook.MythicMobs.registerListener();
-        JobsHook.RoseStacker.registerListener();
+        for (JobsHook hook : JobsHook.values()) {
+            hook.registerListener();
+        }
 
         CMIMessages.consoleMessage("&eListeners registered successfully");
     }

--- a/src/main/java/com/gamingmesh/jobs/actions/EvenMoreFishInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/EvenMoreFishInfo.java
@@ -1,0 +1,27 @@
+package com.gamingmesh.jobs.actions;
+
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.container.BaseActionInfo;
+import com.oheers.fish.api.fishing.items.IFish;
+import com.oheers.fish.api.fishing.items.RarityKey;
+
+public class EvenMoreFishInfo extends BaseActionInfo {
+
+    private final RarityKey key;
+
+    public EvenMoreFishInfo(IFish fish, ActionType type) {
+        super(type);
+        this.key = fish.getRarityKey();
+    }
+
+    @Override
+    public String getName() {
+        return key.toString();
+    }
+
+    @Override
+    public String getNameWithSub() {
+        return key.toString();
+    }
+
+}

--- a/src/main/java/com/gamingmesh/jobs/actions/evenmorefish/EvenMoreFishFishInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/evenmorefish/EvenMoreFishFishInfo.java
@@ -1,15 +1,15 @@
-package com.gamingmesh.jobs.actions;
+package com.gamingmesh.jobs.actions.evenmorefish;
 
 import com.gamingmesh.jobs.container.ActionType;
 import com.gamingmesh.jobs.container.BaseActionInfo;
 import com.oheers.fish.api.fishing.items.IFish;
 import com.oheers.fish.api.fishing.items.RarityKey;
 
-public class EvenMoreFishInfo extends BaseActionInfo {
+public class EvenMoreFishFishInfo extends BaseActionInfo {
 
     private final RarityKey key;
 
-    public EvenMoreFishInfo(IFish fish, ActionType type) {
+    public EvenMoreFishFishInfo(IFish fish, ActionType type) {
         super(type);
         this.key = fish.getRarityKey();
     }

--- a/src/main/java/com/gamingmesh/jobs/actions/evenmorefish/EvenMoreFishRarityInfo.java
+++ b/src/main/java/com/gamingmesh/jobs/actions/evenmorefish/EvenMoreFishRarityInfo.java
@@ -1,0 +1,29 @@
+package com.gamingmesh.jobs.actions.evenmorefish;
+
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.container.BaseActionInfo;
+import com.gmail.nossr50.datatypes.treasure.Rarity;
+import com.oheers.fish.api.fishing.items.IFish;
+import com.oheers.fish.api.fishing.items.IRarity;
+import com.oheers.fish.api.fishing.items.RarityKey;
+
+public class EvenMoreFishRarityInfo extends BaseActionInfo {
+
+    private final IRarity rarity;
+
+    public EvenMoreFishRarityInfo(IFish fish, ActionType type) {
+        super(type);
+        this.rarity = fish.getRarity();
+    }
+
+    @Override
+    public String getName() {
+        return rarity.getId();
+    }
+
+    @Override
+    public String getNameWithSub() {
+        return rarity.getId();
+    }
+
+}

--- a/src/main/java/com/gamingmesh/jobs/container/ActionType.java
+++ b/src/main/java/com/gamingmesh/jobs/container/ActionType.java
@@ -60,7 +60,8 @@ public enum ActionType {
 	BUCKET(CMIMaterial.BUCKET, ActionSubType.MATERIAL),
 	BRUSH(CMIMaterial.BRUSH, ActionSubType.BLOCK, ActionSubType.MATERIAL),
 	WAX(CMIMaterial.HONEYCOMB, ActionSubType.BLOCK, ActionSubType.PROTECTED),
-	SCRAPE(CMIMaterial.WOODEN_AXE, ActionSubType.BLOCK, ActionSubType.PROTECTED);
+	SCRAPE(CMIMaterial.WOODEN_AXE, ActionSubType.BLOCK, ActionSubType.PROTECTED),
+	EVENMOREFISH("EvenMoreFish", CMIMaterial.TROPICAL_FISH, ActionSubType.CUSTOM);
 
 	private String name;
 

--- a/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
@@ -200,10 +200,8 @@ public enum JobsHook {
         @Override
         public void registerListener() {
             if (!isPresent()) {
-                System.out.println("EvenMoreFish is not present.");
                 return;
             }
-            System.out.println("Loading EvenMoreFish listener.");
             Bukkit.getPluginManager().registerEvents(new JobsEvenMoreFishPaymentListener(), Jobs.getInstance());
             printListenerMessage(this);
         }

--- a/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
+++ b/src/main/java/com/gamingmesh/jobs/hooks/JobsHook.java
@@ -1,5 +1,7 @@
 package com.gamingmesh.jobs.hooks;
 
+import com.gamingmesh.jobs.listeners.JobsEvenMoreFishPaymentListener;
+import org.bukkit.Bukkit;
 import org.bukkit.plugin.PluginManager;
 import org.bukkit.plugin.java.JavaPlugin;
 
@@ -191,6 +193,18 @@ public enum JobsHook {
                 return;
 
             JavaPlugin.getPlugin(Jobs.class).getServer().getPluginManager().registerEvents(new JobsCustomFishingPaymentListener(), JavaPlugin.getPlugin(Jobs.class));
+            printListenerMessage(this);
+        }
+    },
+    EvenMoreFish {
+        @Override
+        public void registerListener() {
+            if (!isPresent()) {
+                System.out.println("EvenMoreFish is not present.");
+                return;
+            }
+            System.out.println("Loading EvenMoreFish listener.");
+            Bukkit.getPluginManager().registerEvents(new JobsEvenMoreFishPaymentListener(), Jobs.getInstance());
             printListenerMessage(this);
         }
     };

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsDefaultFishPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsDefaultFishPaymentListener.java
@@ -1,5 +1,6 @@
 package com.gamingmesh.jobs.listeners;
 
+import com.oheers.fish.api.fishing.items.AbstractFishManager;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -65,6 +66,11 @@ public class JobsDefaultFishPaymentListener implements Listener {
                 catchPyroFish = true;
             }
             if (catchPyroFish) return;
+        }
+
+        // EvenMoreFish fires its own event, so ignore this event.
+        if (JobsHook.EvenMoreFish.isEnabled() && AbstractFishManager.getInstance().isFish(event.getCaught())) {
+            return;
         }
 
         Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new ItemActionInfo(((Item) event.getCaught()).getItemStack(), ActionType.FISH), event.getCaught());

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
@@ -1,0 +1,63 @@
+package com.gamingmesh.jobs.listeners;
+
+import com.gamingmesh.jobs.Jobs;
+import com.gamingmesh.jobs.actions.EvenMoreFishInfo;
+import com.gamingmesh.jobs.container.ActionType;
+import com.oheers.fish.api.events.EMFFishCaughtEvent;
+import com.oheers.fish.api.events.EMFFishHuntEvent;
+import com.oheers.fish.api.fishing.items.IFish;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+/**
+ * Listener for EvenMoreFish fish.
+ * Checks both hunting and fishing events.
+ */
+public class JobsEvenMoreFishPaymentListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerCustomFishing(EMFFishCaughtEvent event) {
+        handleEvent(
+            event.getPlayer(),
+            event.getFish()
+        );
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onPlayerCustomFishing(EMFFishHuntEvent event) {
+        handleEvent(
+            event.getPlayer(),
+            event.getFish()
+        );
+    }
+
+    private void handleEvent(Player player, IFish fish) {
+        if (!Jobs.getGCManager().canPerformActionInWorld(player.getWorld())) {
+            return;
+        }
+
+        // check if in creative
+        if (!JobsPaymentListener.payIfCreative(player)) {
+            return;
+        }
+
+        if (!Jobs.getPermissionHandler().hasWorldPermission(player, player.getWorld().getName())) {
+            return;
+        }
+
+        // check if player is riding
+        if (Jobs.getGCManager().disablePaymentIfRiding && player.isInsideVehicle() && !player.getVehicle().getType().toString().contains("BOAT")) {
+            return;
+        }
+
+        if (!JobsPaymentListener.payForItemDurabilityLoss(player)) {
+            return;
+        }
+
+        System.out.println("EvenMoreFish fish: " + fish.getRarityKey().toString());
+        Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new EvenMoreFishInfo(fish, ActionType.EVENMOREFISH));
+    }
+
+}

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
@@ -56,7 +56,6 @@ public class JobsEvenMoreFishPaymentListener implements Listener {
             return;
         }
 
-        System.out.println("EvenMoreFish fish: " + fish.getRarityKey().toString());
         Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new EvenMoreFishInfo(fish, ActionType.EVENMOREFISH));
     }
 

--- a/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
+++ b/src/main/java/com/gamingmesh/jobs/listeners/JobsEvenMoreFishPaymentListener.java
@@ -1,7 +1,8 @@
 package com.gamingmesh.jobs.listeners;
 
 import com.gamingmesh.jobs.Jobs;
-import com.gamingmesh.jobs.actions.EvenMoreFishInfo;
+import com.gamingmesh.jobs.actions.evenmorefish.EvenMoreFishFishInfo;
+import com.gamingmesh.jobs.actions.evenmorefish.EvenMoreFishRarityInfo;
 import com.gamingmesh.jobs.container.ActionType;
 import com.oheers.fish.api.events.EMFFishCaughtEvent;
 import com.oheers.fish.api.events.EMFFishHuntEvent;
@@ -56,7 +57,8 @@ public class JobsEvenMoreFishPaymentListener implements Listener {
             return;
         }
 
-        Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new EvenMoreFishInfo(fish, ActionType.EVENMOREFISH));
+        Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new EvenMoreFishFishInfo(fish, ActionType.EVENMOREFISH));
+        Jobs.action(Jobs.getPlayerManager().getJobsPlayer(player), new EvenMoreFishRarityInfo(fish, ActionType.EVENMOREFISH));
     }
 
 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -8,7 +8,22 @@ website: https://www.spigotmc.org/resources/4216/
 authors: [Zrips]
 contributors: [montlikadani]
 depend: [CMILib]
-softdepend: [Vault, Essentials, MythicMobs, WorldGuard, MyPet, PlaceholderAPI, EcoEnchants, WildStacker, RoseStacker, StackMob, PyroFishingPro, BlockTracker, CustomFishing]
+softdepend: [
+  Vault,
+  Essentials,
+  MythicMobs,
+  WorldGuard,
+  MyPet,
+  PlaceholderAPI,
+  EcoEnchants,
+  WildStacker,
+  RoseStacker,
+  StackMob,
+  PyroFishingPro,
+  BlockTracker,
+  CustomFishing,
+  EvenMoreFish
+]
 commands:
   jobs:
     description: Jobs


### PR DESCRIPTION
Adds support for the [EvenMoreFish](https://modrinth.com/plugin/evenmorefish) plugin.

Changes:
- Added EvenMoreFish to dependencies.
- The vanilla fish event is now ignored if an EMF fish is present.
- Added a listener for EvenMoreFish events.
  - This listener handles both fishing and hunting events.
- `JobsHook#registerListener` is now called in a loop instead of being done manually.

Example Config:
```yaml
  EvenMoreFish:
    # Specific fish
    common:cod:
      experience: 150.0
    # Whole rarity
    rare:
      experience: 200.0
```