### PR TITLE
feat. implement reward modifiers for job calculations

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/Gui/GuiManager.java
+++ b/src/main/java/com/gamingmesh/jobs/Gui/GuiManager.java
@@ -1,14 +1,10 @@
 package com.gamingmesh.jobs.Gui;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -392,6 +388,7 @@ public class GuiManager {
 
         int level = prog != null ? prog.getLevel() : 1;
         int numjobs = jPlayer.getJobProgression().size();
+        Location previewLocation = player.getLocation();
         int nextButton = (rows * 9) - 1;
         int backButton = ((rows - 1) * 9);
 
@@ -439,17 +436,32 @@ public class GuiManager {
                     }
                 }
 
-                double income = jInfo.getIncome(level, numjobs, jPlayer.maxJobsEquation);
-
-                income = boost.getFinalAmount(CurrencyType.MONEY, income);
+                Material material = Material.matchMaterial(jInfo.getName());
+                Map<CurrencyType, Double> rewards = Jobs.calculateRewards(
+                    jPlayer,
+                    job,
+                    jInfo,
+                    level,
+                    numjobs,
+                    null,
+                    null,
+                    null,
+                    null,
+                    action.getType(),
+                    material,
+                    material == null ? jInfo.getName() : null,
+                    previewLocation,
+                    boost,
+                    true,
+                    false
+                );
+                double income = rewards.getOrDefault(CurrencyType.MONEY, 0D);
                 String incomeColor = income >= 0 ? "" : CMIChatColor.DARK_RED.toString();
 
-                double xp = jInfo.getExperience(level, numjobs, jPlayer.maxJobsEquation);
-                xp = boost.getFinalAmount(CurrencyType.EXP, xp);
+                double xp = rewards.getOrDefault(CurrencyType.EXP, 0D);
                 String xpColor = xp >= 0 ? "" : CMIChatColor.GRAY.toString();
 
-                double points = jInfo.getPoints(level, numjobs, jPlayer.maxJobsEquation);
-                points = boost.getFinalAmount(CurrencyType.POINTS, points);
+                double points = rewards.getOrDefault(CurrencyType.POINTS, 0D);
                 String pointsColor = points >= 0 ? "" : CMIChatColor.RED.toString();
 
                 if (income == 0D && points == 0D && xp == 0D)

--- a/src/main/java/com/gamingmesh/jobs/Jobs.java
+++ b/src/main/java/com/gamingmesh/jobs/Jobs.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
@@ -33,6 +34,8 @@ import java.util.WeakHashMap;
 import java.util.logging.Logger;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -50,6 +53,9 @@ import com.gamingmesh.jobs.Signs.SignUtil;
 import com.gamingmesh.jobs.api.JobsExpGainEvent;
 import com.gamingmesh.jobs.api.JobsInstancePaymentEvent;
 import com.gamingmesh.jobs.api.JobsPrePaymentEvent;
+import com.gamingmesh.jobs.api.modifier.JobsRewardModifier;
+import com.gamingmesh.jobs.api.modifier.JobsRewardModifierContext;
+import com.gamingmesh.jobs.api.modifier.JobsRewardModifierResult;
 import com.gamingmesh.jobs.commands.JobsCommands;
 import com.gamingmesh.jobs.config.BlockProtectionManager;
 import com.gamingmesh.jobs.config.BossBarManager;
@@ -180,6 +186,7 @@ public final class Jobs extends JavaPlugin {
 
     private static Job noneJob;
     private static Map<Job, Integer> usedSlots = new WeakHashMap<>();
+    private static final Map<String, JobsRewardModifier> rewardModifiers = new LinkedHashMap<>();
 
     public static BufferedPaymentThread paymentThread;
     private static DatabaseSaveThread saveTask;
@@ -438,6 +445,27 @@ public final class Jobs extends JavaPlugin {
      */
     public static Jobs getInstance() {
         return JavaPlugin.getPlugin(Jobs.class);
+    }
+
+    @SuppressWarnings("unused")
+    public static void registerRewardModifier(JobsRewardModifier modifier) {
+        if (modifier == null || modifier.id() == null || modifier.id().isEmpty())
+            return;
+
+        rewardModifiers.put(modifier.id().toLowerCase(Locale.ROOT), modifier);
+    }
+
+    @SuppressWarnings("unused")
+    public static void unregisterRewardModifier(String id) {
+        if (id == null)
+            return;
+
+        rewardModifiers.remove(id.toLowerCase(Locale.ROOT));
+    }
+
+    @SuppressWarnings("unused")
+    public static Map<String, JobsRewardModifier> getRewardModifiers() {
+        return Collections.unmodifiableMap(rewardModifiers);
     }
 
     /**
@@ -1017,6 +1045,8 @@ public final class Jobs extends JavaPlugin {
             CMIMessages.consoleMessage("&eClosed database connection");
         }
 
+        rewardModifiers.clear();
+
         CMIMessages.consoleMessage(suffix);
     }
 
@@ -1136,39 +1166,35 @@ public final class Jobs extends JavaPlugin {
 
             Boost boost = getPlayerManager().getFinalBonus(jPlayer, noneJob);
 
-            JobsPrePaymentEvent jobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), noneJob, income, 0, pointAmount, block, ent, victim, info);
+            Map<CurrencyType, Double> modifiedRewards = calculateRewards(
+                jPlayer,
+                noneJob,
+                CurrencyType.generate(income, null, pointAmount),
+                info,
+                block,
+                ent,
+                victim,
+                null,
+                null,
+                null,
+                null,
+                null,
+                false,
+                false
+            );
+
+            JobsPrePaymentEvent jobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), noneJob, modifiedRewards.getOrDefault(CurrencyType.MONEY, 0D), 0,
+                modifiedRewards.getOrDefault(CurrencyType.POINTS, 0D), block, ent, victim, info);
             Bukkit.getServer().getPluginManager().callEvent(jobsPrePaymentEvent);
             // If event is canceled, don't do anything
             if (jobsPrePaymentEvent.isCancelled()) {
                 income = 0D;
                 pointAmount = 0D;
             } else {
-                income = jobsPrePaymentEvent.getAmount();
-                pointAmount = jobsPrePaymentEvent.getPoints();
-            }
-
-            // Calculate income
-            if (income != 0D) {
-                income = boost.getFinalAmount(CurrencyType.MONEY, income);
-
-                if (gConfigManager.useMinimumOveralPayment && income > 0) {
-                    double maxLimit = income * gConfigManager.MinimumOveralPaymentLimit;
-
-                    if (income < maxLimit)
-                        income = maxLimit;
-                }
-            }
-
-            // Calculate points
-            if (pointAmount != 0D) {
-                pointAmount = boost.getFinalAmount(CurrencyType.POINTS, pointAmount);
-
-                if (gConfigManager.useMinimumOveralPoints && pointAmount > 0) {
-                    double maxLimit = pointAmount * gConfigManager.MinimumOveralPointsLimit;
-
-                    if (pointAmount < maxLimit)
-                        pointAmount = maxLimit;
-                }
+                Map<CurrencyType, Double> rewards = CurrencyType.generate(jobsPrePaymentEvent.getAmount(), null, jobsPrePaymentEvent.getPoints());
+                applyRewardBoosts(rewards, boost, true);
+                income = rewards.getOrDefault(CurrencyType.MONEY, 0D);
+                pointAmount = rewards.getOrDefault(CurrencyType.POINTS, 0D);
             }
 
             if (!jPlayer.isUnderLimit(CurrencyType.MONEY, income)) {
@@ -1244,6 +1270,44 @@ public final class Jobs extends JavaPlugin {
                 if (income == 0D && pointAmount == 0D && expAmount == 0D)
                     continue;
 
+                Boost boost = getPlayerManager().getFinalBonus(jPlayer, prog.getJob(), ent, victim);
+
+                Map<CurrencyType, Double> modifiedRewards = calculateRewards(
+                    jPlayer,
+                    prog.getJob(),
+                    CurrencyType.generate(income, expAmount, pointAmount),
+                    info,
+                    block,
+                    ent,
+                    victim,
+                    null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    false,
+                    false
+                );
+                income = modifiedRewards.getOrDefault(CurrencyType.MONEY, 0D);
+                pointAmount = modifiedRewards.getOrDefault(CurrencyType.POINTS, 0D);
+                expAmount = modifiedRewards.getOrDefault(CurrencyType.EXP, 0D);
+
+                JobsPrePaymentEvent jobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), prog.getJob(), modifiedRewards, block, ent, victim, info);
+
+                Bukkit.getServer().getPluginManager().callEvent(jobsPrePaymentEvent);
+                // If event is canceled, don't do anything
+                if (jobsPrePaymentEvent.isCancelled()) {
+                    income = 0D;
+                    pointAmount = 0D;
+                    expAmount = 0D;
+                } else {
+                    Map<CurrencyType, Double> rewards = CurrencyType.generate(jobsPrePaymentEvent.getAmount(), jobsPrePaymentEvent.getExp(), jobsPrePaymentEvent.getPoints());
+                    applyRewardBoosts(rewards, boost, true);
+                    income = rewards.getOrDefault(CurrencyType.MONEY, 0D);
+                    pointAmount = rewards.getOrDefault(CurrencyType.POINTS, 0D);
+                    expAmount = rewards.getOrDefault(CurrencyType.EXP, 0D);
+                }
+
                 if (gConfigManager.addXpPlayer()) {
                     Player player = jPlayer.getPlayer();
                     if (player != null) {
@@ -1268,58 +1332,6 @@ public final class Jobs extends JavaPlugin {
                             player.setExp(0);
                         } else
                             player.giveExp(expInt);
-                    }
-                }
-
-                Boost boost = getPlayerManager().getFinalBonus(jPlayer, prog.getJob(), ent, victim);
-
-                JobsPrePaymentEvent jobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), prog.getJob(), CurrencyType.generate(income, expAmount, pointAmount), block, ent, victim, info);
-
-                Bukkit.getServer().getPluginManager().callEvent(jobsPrePaymentEvent);
-                // If event is canceled, don't do anything
-                if (jobsPrePaymentEvent.isCancelled()) {
-                    income = 0D;
-                    pointAmount = 0D;
-                    expAmount = 0D;
-                } else {
-                    income = jobsPrePaymentEvent.getAmount();
-                    pointAmount = jobsPrePaymentEvent.getPoints();
-                    expAmount = jobsPrePaymentEvent.getExp();
-                }
-
-                // Calculate income
-                if (income != 0D) {
-                    income = boost.getFinalAmount(CurrencyType.MONEY, income);
-
-                    if (gConfigManager.useMinimumOveralPayment && income > 0) {
-                        double maxLimit = income * gConfigManager.MinimumOveralPaymentLimit;
-
-                        if (income < maxLimit)
-                            income = maxLimit;
-                    }
-                }
-
-                // Calculate points
-                if (pointAmount != 0D) {
-                    pointAmount = boost.getFinalAmount(CurrencyType.POINTS, pointAmount);
-
-                    if (gConfigManager.useMinimumOveralPoints && pointAmount > 0) {
-                        double maxLimit = pointAmount * gConfigManager.MinimumOveralPointsLimit;
-
-                        if (pointAmount < maxLimit)
-                            pointAmount = maxLimit;
-                    }
-                }
-
-                // Calculate exp
-                if (expAmount != 0D) {
-                    expAmount = boost.getFinalAmount(CurrencyType.EXP, expAmount);
-
-                    if (gConfigManager.useMinimumOveralExp && expAmount > 0) {
-                        double maxLimit = expAmount * gConfigManager.minimumOveralExpLimit;
-
-                        if (expAmount < maxLimit)
-                            expAmount = maxLimit;
                     }
                 }
 
@@ -1460,6 +1472,9 @@ public final class Jobs extends JavaPlugin {
 
         double expPayment = payment.get(CurrencyType.EXP);
 
+        calculateRewards(jPlayer, job, payment.getPayment(), info, block, ent, victim, null, null, null, null, null, false, false);
+        expPayment = payment.get(CurrencyType.EXP);
+
         JobsPrePaymentEvent jobsPrePaymentEvent = new JobsPrePaymentEvent(jPlayer.getPlayer(), job, payment.getPayment(), block, ent, victim, info);
         Bukkit.getServer().getPluginManager().callEvent(jobsPrePaymentEvent);
         // If event is canceled, don't do anything
@@ -1468,6 +1483,9 @@ public final class Jobs extends JavaPlugin {
 
         payment.set(CurrencyType.MONEY, jobsPrePaymentEvent.getAmount());
         payment.set(CurrencyType.POINTS, jobsPrePaymentEvent.getPoints());
+        payment.set(CurrencyType.EXP, jobsPrePaymentEvent.getExp());
+
+        expPayment = payment.get(CurrencyType.EXP);
 
         JobsExpGainEvent jobsExpGainEvent = new JobsExpGainEvent(payment.getOfflinePlayer(), job, expPayment, block, ent, victim, info);
         Bukkit.getServer().getPluginManager().callEvent(jobsExpGainEvent);
@@ -1509,6 +1527,89 @@ public final class Jobs extends JavaPlugin {
             return;
 
         payOut(jPlayer, payment.getPayment());
+    }
+
+    public static void applyRewardModifiers(JobsPlayer jPlayer, Job job, Map<CurrencyType, Double> rewards, Block block, Entity ent, LivingEntity victim, ActionInfo info) {
+        applyRewardModifiers(jPlayer, job, rewards, block, ent, victim, info, null, null, null);
+    }
+
+    public static void applyRewardModifiers(JobsPlayer jPlayer, Job job, Map<CurrencyType, Double> rewards, ActionType actionType, Material material, String entityKey, Location location) {
+        applyRewardModifiers(jPlayer, job, rewards, null, null, null, null, actionType, actionType == null ? null : actionType.name(), material, entityKey, location);
+    }
+
+    public static Map<CurrencyType, Double> calculateRewards(JobsPlayer jPlayer, Job job, JobInfo jobInfo, int level, int numjobs, ActionInfo info,
+        Block block, Entity ent, LivingEntity victim, ActionType actionType, Material material, String entityKey, Location location, Boost boost,
+        boolean applyBoosts, boolean applyMinimums) {
+        Map<CurrencyType, Double> rewards = CurrencyType.generate(
+            jobInfo.getIncome(level, numjobs, jPlayer.maxJobsEquation),
+            jobInfo.getExperience(level, numjobs, jPlayer.maxJobsEquation),
+            jobInfo.getPoints(level, numjobs, jPlayer.maxJobsEquation)
+        );
+        return calculateRewards(jPlayer, job, rewards, info, block, ent, victim, actionType, material, entityKey, location, boost, applyBoosts, applyMinimums);
+    }
+
+    public static Map<CurrencyType, Double> calculateRewards(JobsPlayer jPlayer, Job job, Map<CurrencyType, Double> rewards, ActionInfo info,
+        Block block, Entity ent, LivingEntity victim, ActionType actionType, Material material, String entityKey, Location location, Boost boost,
+        boolean applyBoosts, boolean applyMinimums) {
+        applyRewardModifiers(jPlayer, job, rewards, block, ent, victim, info, actionType, actionType == null ? null : actionType.name(), material, entityKey, location);
+
+        if (applyBoosts && boost != null) {
+            applyRewardBoosts(rewards, boost, applyMinimums);
+        }
+
+        return rewards;
+    }
+
+    private static void applyRewardBoosts(Map<CurrencyType, Double> rewards, Boost boost, boolean applyMinimums) {
+        applyRewardBoost(rewards, boost, CurrencyType.MONEY);
+        applyRewardBoost(rewards, boost, CurrencyType.POINTS);
+        applyRewardBoost(rewards, boost, CurrencyType.EXP);
+
+        if (applyMinimums) {
+            applyMinimumReward(rewards, CurrencyType.MONEY, gConfigManager.useMinimumOveralPayment, gConfigManager.MinimumOveralPaymentLimit);
+            applyMinimumReward(rewards, CurrencyType.POINTS, gConfigManager.useMinimumOveralPoints, gConfigManager.MinimumOveralPointsLimit);
+            applyMinimumReward(rewards, CurrencyType.EXP, gConfigManager.useMinimumOveralExp, gConfigManager.minimumOveralExpLimit);
+        }
+    }
+
+    private static void applyRewardBoost(Map<CurrencyType, Double> rewards, Boost boost, CurrencyType type) {
+        double amount = rewards.getOrDefault(type, 0D);
+        if (amount != 0D) {
+            rewards.put(type, boost.getFinalAmount(type, amount));
+        }
+    }
+
+    private static void applyMinimumReward(Map<CurrencyType, Double> rewards, CurrencyType type, boolean enabled, double limit) {
+        double amount = rewards.getOrDefault(type, 0D);
+        if (enabled && amount > 0) {
+            double maxLimit = amount * limit;
+            if (amount < maxLimit) {
+                rewards.put(type, maxLimit);
+            }
+        }
+    }
+
+    private static void applyRewardModifiers(JobsPlayer jPlayer, Job job, Map<CurrencyType, Double> rewards, Block block, Entity ent, LivingEntity victim, ActionInfo info,
+        Material material, String entityKey, Location location) {
+        applyRewardModifiers(jPlayer, job, rewards, block, ent, victim, info, null, null, material, entityKey, location);
+    }
+
+    private static void applyRewardModifiers(JobsPlayer jPlayer, Job job, Map<CurrencyType, Double> rewards, Block block, Entity ent, LivingEntity victim, ActionInfo info,
+        ActionType actionType, String actionName, Material material, String entityKey, Location location) {
+        if (rewardModifiers.isEmpty() || rewards == null || rewards.isEmpty())
+            return;
+
+        for (JobsRewardModifier modifier : rewardModifiers.values()) {
+            try {
+                JobsRewardModifierContext context = new JobsRewardModifierContext(jPlayer.getPlayer(), job, rewards, block, ent, victim, info, actionType, actionName, location, material, entityKey);
+                JobsRewardModifierResult result = modifier.modify(context);
+                if (result != null) {
+                    result.apply(rewards);
+                }
+            } catch (Throwable throwable) {
+                getPluginLogger().warning("Reward modifier '" + modifier.id() + "' failed: " + throwable.getMessage());
+            }
+        }
     }
 
     private static void payOut(JobsPlayer jPlayer, Map<CurrencyType, Double> payments) {

--- a/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifier.java
+++ b/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifier.java
@@ -1,0 +1,23 @@
+package com.gamingmesh.jobs.api.modifier;
+
+/**
+ * Allows external plugins to adjust Jobs rewards before Jobs applies its own
+ * boosts, limits and final payout logic.
+ */
+public interface JobsRewardModifier {
+
+    /**
+     * Stable modifier identifier, used to replace or unregister this modifier.
+     *
+     * @return unique modifier id
+     */
+    String id();
+
+    /**
+     * Resolves the reward modification for a Jobs action.
+     *
+     * @param context action and reward context
+     * @return modifier result, or {@code null} to leave rewards unchanged
+     */
+    JobsRewardModifierResult modify(JobsRewardModifierContext context);
+}

--- a/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifierContext.java
+++ b/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifierContext.java
@@ -1,0 +1,124 @@
+package com.gamingmesh.jobs.api.modifier;
+
+import com.gamingmesh.jobs.container.ActionInfo;
+import com.gamingmesh.jobs.container.ActionType;
+import com.gamingmesh.jobs.container.CurrencyType;
+import com.gamingmesh.jobs.container.Job;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public final class JobsRewardModifierContext {
+
+    private final OfflinePlayer player;
+    private final Job job;
+    private final Map<CurrencyType, Double> rewards;
+    private final Block block;
+    private final Entity entity;
+    private final LivingEntity livingEntity;
+    private final ActionInfo actionInfo;
+    private final ActionType actionType;
+    private final String actionName;
+    private final Location actionLocation;
+    private final Material material;
+    private final String entityKey;
+
+    public JobsRewardModifierContext(OfflinePlayer player, Job job, Map<CurrencyType, Double> rewards, Block block, Entity entity,
+            LivingEntity livingEntity, ActionInfo actionInfo) {
+        this(player, job, rewards, block, entity, livingEntity, actionInfo, null, null, null, null, null);
+    }
+
+    public JobsRewardModifierContext(OfflinePlayer player, Job job, Map<CurrencyType, Double> rewards, Block block, Entity entity,
+            LivingEntity livingEntity, ActionInfo actionInfo, Location actionLocation, Material material, String entityKey) {
+        this(player, job, rewards, block, entity, livingEntity, actionInfo, null, null, actionLocation, material, entityKey);
+    }
+
+    public JobsRewardModifierContext(OfflinePlayer player, Job job, Map<CurrencyType, Double> rewards, Block block, Entity entity,
+            LivingEntity livingEntity, ActionInfo actionInfo, ActionType actionType, String actionName, Location actionLocation, Material material, String entityKey) {
+        this.player = player;
+        this.job = job;
+        this.rewards = Collections.unmodifiableMap(new LinkedHashMap<>(rewards));
+        this.block = block;
+        this.entity = entity;
+        this.livingEntity = livingEntity;
+        this.actionInfo = actionInfo;
+        this.actionType = actionType == null && actionInfo != null ? actionInfo.getType() : actionType;
+        this.actionName = actionName;
+        this.actionLocation = actionLocation;
+        this.material = material;
+        this.entityKey = entityKey;
+    }
+
+    public OfflinePlayer getPlayer() {
+        return player;
+    }
+
+    public Job getJob() {
+        return job;
+    }
+
+    public Map<CurrencyType, Double> getRewards() {
+        return rewards;
+    }
+
+    public double getReward(CurrencyType type) {
+        return rewards.getOrDefault(type, 0D);
+    }
+
+    public Block getBlock() {
+        return block;
+    }
+
+    public Entity getEntity() {
+        return entity;
+    }
+
+    public LivingEntity getLivingEntity() {
+        return livingEntity;
+    }
+
+    public ActionInfo getActionInfo() {
+        return actionInfo;
+    }
+
+    public ActionType getActionType() {
+        return actionType;
+    }
+
+    public String getActionName() {
+        if (actionName != null)
+            return actionName;
+        return actionType == null ? "ANY" : actionType.name();
+    }
+
+    public Location getActionLocation() {
+        if (actionLocation != null)
+            return actionLocation;
+        if (block != null)
+            return block.getLocation();
+
+        Entity target = livingEntity != null ? livingEntity : entity;
+        return target == null ? null : target.getLocation();
+    }
+
+    public Material getMaterial() {
+        if (material != null)
+            return material;
+        return block == null ? null : block.getType();
+    }
+
+    public String getEntityKey() {
+        if (entityKey != null)
+            return entityKey;
+        Entity target = livingEntity != null ? livingEntity : entity;
+        return target == null ? null : target.getType().name();
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifierResult.java
+++ b/src/main/java/com/gamingmesh/jobs/api/modifier/JobsRewardModifierResult.java
@@ -1,0 +1,64 @@
+package com.gamingmesh.jobs.api.modifier;
+
+import com.gamingmesh.jobs.container.CurrencyType;
+
+import java.util.Map;
+
+@SuppressWarnings("unused")
+public final class JobsRewardModifierResult {
+
+    private final double multiplier;
+    private final boolean applyMoney;
+    private final boolean applyExp;
+    private final boolean applyPoints;
+
+    private JobsRewardModifierResult(double multiplier, boolean applyMoney, boolean applyExp, boolean applyPoints) {
+        this.multiplier = multiplier;
+        this.applyMoney = applyMoney;
+        this.applyExp = applyExp;
+        this.applyPoints = applyPoints;
+    }
+
+    public static JobsRewardModifierResult multiplier(double multiplier) {
+        return new JobsRewardModifierResult(multiplier, true, true, true);
+    }
+
+    public static JobsRewardModifierResult multiplier(double multiplier, boolean applyMoney, boolean applyExp, boolean applyPoints) {
+        return new JobsRewardModifierResult(multiplier, applyMoney, applyExp, applyPoints);
+    }
+
+    public double getMultiplier() {
+        return multiplier;
+    }
+
+    public boolean isApplyMoney() {
+        return applyMoney;
+    }
+
+    public boolean isApplyExp() {
+        return applyExp;
+    }
+
+    public boolean isApplyPoints() {
+        return applyPoints;
+    }
+
+    public void apply(Map<CurrencyType, Double> rewards) {
+        if (rewards == null || Double.isNaN(multiplier) || Double.isInfinite(multiplier))
+            return;
+
+        if (applyMoney)
+            multiply(rewards, CurrencyType.MONEY);
+        if (applyExp)
+            multiply(rewards, CurrencyType.EXP);
+        if (applyPoints)
+            multiply(rewards, CurrencyType.POINTS);
+    }
+
+    private void multiply(Map<CurrencyType, Double> rewards, CurrencyType type) {
+        Double value = rewards.get(type);
+        if (value != null) {
+            rewards.put(type, value * multiplier);
+        }
+    }
+}

--- a/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/JobsCommands.java
@@ -3,10 +3,13 @@ package com.gamingmesh.jobs.commands;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 
 import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -369,22 +372,39 @@ public class JobsCommands implements CommandExecutor {
 
         int level = prog != null ? prog.getLevel() : 1;
         int numjobs = player.getJobCount();
+        Player onlinePlayer = player.getPlayer();
+        Location previewLocation = onlinePlayer == null ? null : onlinePlayer.getLocation();
 
         for (JobInfo info : job.getJobInfo(type)) {
 
             String materialName = info.getRealisticName();
 
-            double income = info.getIncome(level, numjobs, player.maxJobsEquation);
-
-            income = boost.getFinalAmount(CurrencyType.MONEY, income);
+            Material material = Material.matchMaterial(info.getName());
+            Map<CurrencyType, Double> rewards = Jobs.calculateRewards(
+                player,
+                job,
+                info,
+                level,
+                numjobs,
+                null,
+                null,
+                null,
+                null,
+                type,
+                material,
+                material == null ? info.getName() : null,
+                previewLocation,
+                boost,
+                true,
+                false
+            );
+            double income = rewards.getOrDefault(CurrencyType.MONEY, 0D);
             String incomeColor = income >= 0 ? "" : CMIChatColor.DARK_RED.toString();
 
-            double xp = info.getExperience(level, numjobs, player.maxJobsEquation);
-            xp = boost.getFinalAmount(CurrencyType.EXP, xp);
+            double xp = rewards.getOrDefault(CurrencyType.EXP, 0D);
             String xpColor = xp >= 0 ? "" : CMIChatColor.GRAY.toString();
 
-            double points = info.getPoints(level, numjobs, player.maxJobsEquation);
-            points = boost.getFinalAmount(CurrencyType.POINTS, points);
+            double points = rewards.getOrDefault(CurrencyType.POINTS, 0D);
             String pointsColor = xp >= 0 ? "" : CMIChatColor.RED.toString();
 
             if (income == 0D && points == 0D && xp == 0D)

--- a/src/main/java/com/gamingmesh/jobs/commands/list/howmuch.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/howmuch.java
@@ -1,6 +1,7 @@
 package com.gamingmesh.jobs.commands.list;
 
 import java.util.List;
+import java.util.Map;
 
 import org.bukkit.block.Block;
 import org.bukkit.block.data.Ageable;
@@ -155,45 +156,27 @@ public class howmuch implements Cmd {
                 if (jobinfo == null)
                     continue;
 
-                double income = jobinfo.getIncome(prog.getLevel(), numjobs, jPlayer.maxJobsEquation);
-                double pointAmount = jobinfo.getPoints(prog.getLevel(), numjobs, jPlayer.maxJobsEquation);
-                double expAmount = jobinfo.getExperience(prog.getLevel(), numjobs, jPlayer.maxJobsEquation);
-
-                // Calculate income
-                if (income != 0D) {
-                    income = boost.getFinalAmount(CurrencyType.MONEY, income);
-
-                    if (Jobs.getGeneralConfigManager().useMinimumOveralPayment && income > 0) {
-                        double maxLimit = income * Jobs.getGeneralConfigManager().MinimumOveralPaymentLimit;
-
-                        if (income < maxLimit)
-                            income = maxLimit;
-                    }
-                }
-
-                // Calculate points
-                if (pointAmount != 0D) {
-                    pointAmount = boost.getFinalAmount(CurrencyType.POINTS, pointAmount);
-
-                    if (Jobs.getGeneralConfigManager().useMinimumOveralPoints && pointAmount > 0) {
-                        double maxLimit = pointAmount * Jobs.getGeneralConfigManager().MinimumOveralPointsLimit;
-
-                        if (pointAmount < maxLimit)
-                            pointAmount = maxLimit;
-                    }
-                }
-
-                // Calculate exp
-                if (expAmount != 0D) {
-                    expAmount = boost.getFinalAmount(CurrencyType.EXP, expAmount);
-
-                    if (Jobs.getGeneralConfigManager().useMinimumOveralExp && expAmount > 0) {
-                        double maxLimit = expAmount * Jobs.getGeneralConfigManager().minimumOveralExpLimit;
-
-                        if (expAmount < maxLimit)
-                            expAmount = maxLimit;
-                    }
-                }
+                Map<CurrencyType, Double> rewards = Jobs.calculateRewards(
+                    jPlayer,
+                    prog.getJob(),
+                    jobinfo,
+                    prog.getLevel(),
+                    numjobs,
+                    info,
+                    block,
+                    entity,
+                    entity instanceof LivingEntity ? (LivingEntity) entity : null,
+                    null,
+                    null,
+                    null,
+                    null,
+                    boost,
+                    true,
+                    true
+                );
+                double income = rewards.getOrDefault(CurrencyType.MONEY, 0D);
+                double pointAmount = rewards.getOrDefault(CurrencyType.POINTS, 0D);
+                double expAmount = rewards.getOrDefault(CurrencyType.EXP, 0D);
                 payments++;
 
                 Language.sendMessage(sender, "command.version.output.payment", "[job]", prog.getJob().getDisplayName(), "[action]", one, "[target]", name,


### PR DESCRIPTION
Hello, i wanted to add a boost of jobs reward depending on where the player is or another context from another plugin so i guess the best method is to add JobsRewardModifier to the API and with that i'm able to edit it.