### PR TITLE
Round experience in gtop to 2 decimals

### DIFF
--- a/src/main/java/com/gamingmesh/jobs/commands/list/gtop.java
+++ b/src/main/java/com/gamingmesh/jobs/commands/list/gtop.java
@@ -95,14 +95,14 @@ public class gtop implements Cmd {
                     "%playername%", jPlayer.getName(),
                     "%playerdisplayname%", jPlayer.getDisplayName(),
                     "%level%", stats.getLevel(),
-                    "%exp%", stats.getExperience()));
+                    "%exp%", Math.round(stats.getExperience() * 100.00)/100.00));
             else
                 ls.add(Jobs.getLanguage().getMessage("command.gtop.output.list",
                     "%number%", pi.getPositionForOutput(i),
                     "%playername%", jPlayer.getName(),
                     "%playerdisplayname%", jPlayer.getDisplayName(),
                     "%level%", stats.getLevel(),
-                    "%exp%", stats.getExperience()));
+                    "%exp%", Math.round(stats.getExperience() * 100.00)/100.00));
         }
 
         if (Jobs.getGCManager().ShowToplistInScoreboard && sender instanceof Player) {


### PR DESCRIPTION
Experience in gtop is currently showing up to 11 decimal places.  This rounds it off to a max of 2.